### PR TITLE
Fix precedence of **

### DIFF
--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1360,6 +1360,13 @@ describe('Wollok parser', () => {
           'args.0.value.members.0.body.sentences.0.value.args.0.value.members.0.body.sentences.0.value.args.0').tracedTo(23, 24)
     })
 
+    describe('**', () => {
+      it('has more precedence than *', () => {
+        'a * b ** c'.should.be.parsedBy(parser).into(
+          Send(Reference('a'), '*',
+            [Send(Reference('b'), '**', [Reference('c')])]))
+      })
+    })
 
   })
 


### PR DESCRIPTION
Precedence of ** was wrong on method parser.

This is because in most places where we were generating a parser for a list of operators, the list of operators was sometimes ordered in an unconvenient way (for example, * was before ** on that list).

In order to solve this a new parser was added that receives the operators list as a parameter, and returns a parser that will always try the greediest operators first (it orders them in a way that will have ** before *). Did this instead of just reordering the list of OPERATORS because the pattern ...OPERATORS.map(key) was getting repeated all over the place, but we could have also implemented it by reordering the OPERATORS constant.