### PR TITLE
Put RETURN tests together with others

### DIFF
--- a/test/interpreter.test.ts
+++ b/test/interpreter.test.ts
@@ -983,50 +983,49 @@ describe('Wollok Interpreter', () => {
 
     })
 
+    describe('RETURN', () => {
+
+      const instruction = RETURN
+
+      it('should drop the current frame and push the top of its operand stack to the next active frame', () => {
+        const evaluation = Evaluation(environment, {
+          1: RuntimeObject('1', 'wollok.lang.Object'),
+          2: RuntimeObject('2', 'wollok.lang.Object'),
+        }, {
+          3: { id: '3', parent: '4', locals: {} },
+          4: { id: '4', parent: '', locals: {} },
+        })(
+          Frame({ id: '3', context: '3', operandStack: ['1'], instructions: [instruction] }),
+          Frame({ id: '4', context: '4', operandStack: ['2'] }),
+        )
+
+        evaluation.should.be.stepped().into(Evaluation(environment, {
+          1: RuntimeObject('1', 'wollok.lang.Object'),
+          2: RuntimeObject('2', 'wollok.lang.Object'),
+        }, {
+          3: { id: '3', parent: '4', locals: {} },
+          4: { id: '4', parent: '', locals: {} },
+        })(Frame({ id: '4', context: '4', operandStack: ['2', '1'] })))
+
+      })
+
+      it('should raise an error if the current operand stack is empty', () => {
+        const evaluation = Evaluation(environment, {})(
+          Frame({ instructions: [instruction] }),
+          Frame({}),
+        )
+
+        expect(() => step({})(evaluation)).to.throw()
+      })
+
+      it('should raise an error if the frame stack length is < 2', () => {
+        const evaluation = Evaluation(environment, { 1: RuntimeObject('1', 'wollok.lang.Object') })(Frame({ instructions: [instruction], operandStack: ['1'] }))
+
+        expect(() => step({})(evaluation)).to.throw()
+      })
+
+    })
+
   })
-
-
-  describe('RETURN', () => {
-
-    const instruction = RETURN
-
-    it('should drop the current frame and push the top of its operand stack to the next active frame', () => {
-      const evaluation = Evaluation(environment, {
-        1: RuntimeObject('1', 'wollok.lang.Object'),
-        2: RuntimeObject('2', 'wollok.lang.Object'),
-      }, {
-        3: { id: '3', parent: '4', locals: {} },
-        4: { id: '4', parent: '', locals: {} },
-      })(
-        Frame({ id: '3', context: '3', operandStack: ['1'], instructions: [instruction] }),
-        Frame({ id: '4', context: '4', operandStack: ['2'] }),
-      )
-
-      evaluation.should.be.stepped().into(Evaluation(environment, {
-        1: RuntimeObject('1', 'wollok.lang.Object'),
-        2: RuntimeObject('2', 'wollok.lang.Object'),
-      }, {
-        3: { id: '3', parent: '4', locals: {} },
-        4: { id: '4', parent: '', locals: {} },
-      })(Frame({ id: '4', context: '4', operandStack: ['2', '1'] })))
-
-    })
-
-    it('should raise an error if the current operand stack is empty', () => {
-      const evaluation = Evaluation(environment, {})(
-        Frame({ instructions: [instruction] }),
-        Frame({}),
-      )
-
-      expect(() => step({})(evaluation)).to.throw()
-    })
-
-    it('should raise an error if the frame stack length is < 2', () => {
-      const evaluation = Evaluation(environment, { 1: RuntimeObject('1', 'wollok.lang.Object') })(Frame({ instructions: [instruction], operandStack: ['1'] }))
-
-      expect(() => step({})(evaluation)).to.throw()
-    })
-
-  })
-
+  
 })


### PR DESCRIPTION
Inside intepreter tests RETURN tests do not follow the same structure as the others.
I moved it inside the other scope, trying to keep indentation correctly.