### PR TITLE
Fix sanities

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:lint": "eslint .",
     "test:unit": "mocha --parallel -r ts-node/register test/**/*.test.ts",
     "test:examples": "npm run test:wtest -- --root language/test/examples",
-    "test:sanity": "npm run test:wtest -- --root language/test/sanity --ignore mirror/instanceVariableMirror.wtest --ignore game/sounds.wtest --ignore testing/describe/describeWithTestsFlagOnly.wtest --ignore testing/tests/flagOnly.wtest",
+    "test:sanity": "npm run test:wtest -- --root language/test/sanity --ignore mirror/instanceVariableMirror.wtest --ignore game/sounds.wtest",
     "test:game": "npm run test:wtest -- --root test",
     "test:wtest": "mocha --parallel -t 10000 -r ts-node/register test/wtest.ts",
     "prepublishOnly": "npm run build && npm test",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:lint": "eslint .",
     "test:unit": "mocha --parallel -r ts-node/register test/**/*.test.ts",
     "test:examples": "npm run test:wtest -- --root language/test/examples",
-    "test:sanity": "npm run test:wtest -- --root language/test/sanity --ignore mirror/instanceVariableMirror.wtest --ignore game/sounds.wtest",
+    "test:sanity": "npm run test:wtest -- --root language/test/sanity --ignore mirror/instanceVariableMirror.wtest",
     "test:game": "npm run test:wtest -- --root test",
     "test:wtest": "mocha --parallel -t 10000 -r ts-node/register test/wtest.ts",
     "prepublishOnly": "npm run build && npm test",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -12,6 +12,7 @@ const PREFIX_OPERATORS: Record<Name, Name> = {
   '!': 'negate',
   '-': 'invert',
   '+': 'plus',
+  'not': 'negate',
 }
 
 const ASSIGNATION_OPERATORS = ['=', '||=', '/=', '-=', '+=', '*=', '&&=', '%=']

--- a/src/wre/gameMirror.wlk
+++ b/src/wre/gameMirror.wlk
@@ -30,7 +30,7 @@ object gameMirror {
 	method onTick(milliseconds, name, action) {
 		var times = 0
 		const initTime = io.currentTime()
-		io.addTimeHandler(name, { time => if ((time - initTime).div(milliseconds) > times) { action.apply(); times+=1 } })
+		io.addTimeHandler(name, { time => if (milliseconds == 0 or (time - initTime).div(milliseconds) > times) { action.apply(); times+=1 } })
 	}
 
 	method schedule(milliseconds, action) {

--- a/src/wre/io.wlk
+++ b/src/wre/io.wlk
@@ -49,7 +49,7 @@ object io {
       eventHandlers.getOrElse(event, { [] }).forEach{ callback => callback.apply() }
     }
 
-    timeHandlers.values().flatten().forEach{ callback => try { callback.apply(time) } catch e { errorHandler.apply(e) } }
+    timeHandlers.values().flatten().forEach{ callback => try { callback.apply(time) } catch e: DomainException { errorHandler.apply(e) } }
     currentTime = time
   }
 

--- a/src/wre/io.wlk
+++ b/src/wre/io.wlk
@@ -46,11 +46,20 @@ object io {
     const currentEvents = eventQueue.copy()
     eventQueue = []
     currentEvents.forEach{ event =>
-      eventHandlers.getOrElse(event, { [] }).forEach{ callback => callback.apply() }
+      eventHandlers.getOrElse(event, { [] }).forEach{ callback => self.runHandler({ callback.apply() }) }
     }
 
-    timeHandlers.values().flatten().forEach{ callback => try { callback.apply(time) } catch e: DomainException { errorHandler.apply(e) } }
+    timeHandlers.values().flatten().forEach{ callback => self.runHandler({ callback.apply(time) }) }
     currentTime = time
+  }
+
+  method runHandler(callback) {
+    try { 
+      callback.apply() 
+    } catch e: DomainException { 
+      errorHandler.apply(e) 
+    }
+    //TODO: catch Exception ?
   }
 
 }

--- a/src/wre/io.wlk
+++ b/src/wre/io.wlk
@@ -5,6 +5,7 @@ object io {
   const property timeHandlers = new Dictionary()
   var property eventQueue = []
   var property currentTime = 0
+  var property errorHandler = { exception => }
 
   method queueEvent(event) {
     eventQueue.add(event)
@@ -48,7 +49,7 @@ object io {
       eventHandlers.getOrElse(event, { [] }).forEach{ callback => callback.apply() }
     }
 
-    timeHandlers.values().flatten().forEach{ callback => callback.apply(time) }
+    timeHandlers.values().flatten().forEach{ callback => try { callback.apply(time) } catch e { errorHandler.apply(e) } }
     currentTime = time
   }
 

--- a/test/game/events.wtest
+++ b/test/game/events.wtest
@@ -139,34 +139,42 @@ describe 'events' {
 
 
   test 'schedule once called' {
-      game.schedule(1000, closureMock)
-      io.flushEvents(1000)
-      assert.that(closureMock.called())
+    game.schedule(1000, closureMock)
+    io.flushEvents(1000)
+    assert.that(closureMock.called())
   }
 
   test 'schedule only once called' {
-      game.schedule(1000, closureMock)
-      io.flushEvents(1000)
-      io.flushEvents(2000)
-      assert.equals(1, closureMock.calledCount())
+    game.schedule(1000, closureMock)
+    io.flushEvents(1000)
+    io.flushEvents(2000)
+    assert.equals(1, closureMock.calledCount())
   }
 
   test 'schedule on 0 ms should not throws exception' {
-      io.errorHandler(closureErrorMock)
-      game.schedule(0, closureMock)
-      io.flushEvents(0)
+    io.errorHandler(closureErrorMock)
+    game.schedule(0, closureMock)
+    io.flushEvents(0)
   }
 
 
-  test 'throws exception on event should not propagate' {
-      game.schedule(0, closureErrorMock)
-      io.flushEvents(0)
+  // TODO: Move to io.wtest
+  test 'throws exception on time event should not propagate' {
+    game.schedule(0, closureErrorMock)
+    io.flushEvents(0)
+  }
+
+  test 'throws exception on queue event should not propagate' {
+    const event = ["keypress", "KeyA"]
+    keyboard.a().onPressDo(closureErrorMock)
+    io.queueEvent(event)
+    io.flushEvents(0)
   }
 
   test 'throws exception on event with error handler' {
-      io.errorHandler(closureMock)
-      game.schedule(0, closureErrorMock)
-      io.flushEvents(0)
-      assert.that(closureMock.called())
+    io.errorHandler(closureMock)
+    game.schedule(0, closureErrorMock)
+    io.flushEvents(0)
+    assert.that(closureMock.called())
   }
 }

--- a/test/game/events.wtest
+++ b/test/game/events.wtest
@@ -156,25 +156,5 @@ describe 'events' {
     game.schedule(0, closureMock)
     io.flushEvents(0)
   }
-
-
-  // TODO: Move to io.wtest
-  test 'throws exception on time event should not propagate' {
-    game.schedule(0, closureErrorMock)
-    io.flushEvents(0)
-  }
-
-  test 'throws exception on queue event should not propagate' {
-    const event = ["keypress", "KeyA"]
-    keyboard.a().onPressDo(closureErrorMock)
-    io.queueEvent(event)
-    io.flushEvents(0)
-  }
-
-  test 'throws exception on event with error handler' {
-    io.errorHandler(closureMock)
-    game.schedule(0, closureErrorMock)
-    io.flushEvents(0)
-    assert.that(closureMock.called())
-  }
+  
 }

--- a/test/game/events.wtest
+++ b/test/game/events.wtest
@@ -7,6 +7,10 @@ object closureMock {
   method apply(args...) { calledCount += 1 }
 }
 
+object closureErrorMock {
+  method apply(args...) { self.error('FAIL') }
+}
+
 class Visual {
   var property position = game.origin()
 }
@@ -145,5 +149,18 @@ describe 'events' {
       io.flushEvents(1000)
       io.flushEvents(2000)
       assert.equals(1, closureMock.calledCount())
+  }
+
+
+  test 'throws exception on event should not propagate' {
+      game.schedule(0, closureErrorMock)
+      io.flushEvents(0)
+  }
+
+  test 'throws exception on event with error handler' {
+      io.errorHandler(closureMock)
+      game.schedule(0, closureErrorMock)
+      io.flushEvents(0)
+      assert.that(closureMock.called())
   }
 }

--- a/test/game/events.wtest
+++ b/test/game/events.wtest
@@ -151,6 +151,12 @@ describe 'events' {
       assert.equals(1, closureMock.calledCount())
   }
 
+  test 'schedule on 0 ms should not throws exception' {
+      io.errorHandler(closureErrorMock)
+      game.schedule(0, closureMock)
+      io.flushEvents(0)
+  }
+
 
   test 'throws exception on event should not propagate' {
       game.schedule(0, closureErrorMock)

--- a/test/game/io.wtest
+++ b/test/game/io.wtest
@@ -8,6 +8,10 @@ object closureMock {
   method apply(args...) { calls.add(args) }
 }
 
+object closureErrorMock {
+  method apply(args...) { self.error('FAIL') }
+}
+
 describe 'flush events' {
 
   test 'should clear event queue' {
@@ -46,5 +50,24 @@ describe 'flush events' {
   test 'should update current time' {
     io.flushEvents(100)
     assert.equals(100, io.currentTime())
+  }
+
+
+  test 'throws exception on queue event should not propagate' {
+    io.queueEvent('EVENT')
+    io.addEventHandler('EVENT', closureErrorMock)
+    io.flushEvents(0)
+  }
+
+  test 'throws exception on time event should not propagate' {
+    io.addTimeHandler('', closureErrorMock)
+    io.flushEvents(0)
+  }
+
+  test 'throws exception on event with error handler' {
+    io.errorHandler(closureMock)
+    io.addTimeHandler('', closureErrorMock)
+    io.flushEvents(0)
+    assert.that(closureMock.called())
   }
 }

--- a/test/wtest.ts
+++ b/test/wtest.ts
@@ -30,11 +30,16 @@ const ARGUMENTS = yargs
   .argv
 
 
+function selectTests(nodes: List<Node>) {
+  const onlyTest = nodes.find(node => node.is('Test') && node.isOnly)
+  return onlyTest ? [onlyTest] : nodes
+}
+
 function registerTests(evaluation: Evaluation, nodes: List<Node>) {
   nodes.forEach(node => {
 
     if (node.is('Describe') || node.is('Package'))
-      describe(node.name, () => registerTests(evaluation, node.members))
+      describe(node.name, () => registerTests(evaluation, selectTests(node.members)))
 
     if (node.is('Test'))
       it(node.name, () => {


### PR DESCRIPTION
Fix https://github.com/uqbar-project/wollok-ts/issues/64
Fix https://github.com/uqbar-project/wollok-ts/issues/66
También agregué un `errorHandler` al objeto `io` para implementar esto en un futuro: https://github.com/uqbar-project/wollok-ts/issues/69

Agregué unos sanity para el `not` en https://github.com/uqbar-project/wollok-language/pull/81 y ya se banca todos los sanity de lang (master) excepto los de `instanceVariableMirror` que queda para después.