### PR TITLE
Deprecated methods

### DIFF
--- a/src/wre/game.ts
+++ b/src/wre/game.ts
@@ -61,7 +61,7 @@ const game: Natives = {
 
       const result: RuntimeObject[] = []
       for(const visual of visuals) {
-        const otherPosition = visual.get('position') ?? (yield* this.send('position', visual))!
+        const otherPosition = (yield* this.send('position', visual))!
         if((yield *this.send('==', position, otherPosition))!.innerBoolean)
           result.push(visual)
       }
@@ -86,7 +86,7 @@ const game: Natives = {
     *colliders(self: RuntimeObject, visual: RuntimeObject): Execution<RuntimeValue> {
       visual.assertIsNotNull()
 
-      const position = visual.get('position') ?? (yield* this.send('position', visual))!
+      const position = (yield* this.send('position', visual))!
       const visualsAtPosition: RuntimeObject = (yield* this.send('getObjectsIn', self, position))!
 
       yield* this.send('remove', visualsAtPosition, visual)

--- a/src/wre/game.ts
+++ b/src/wre/game.ts
@@ -14,26 +14,8 @@ const game: Natives = {
       visuals.push(visual)
     },
 
-    *addVisualIn(self: RuntimeObject, visual: RuntimeObject, position: RuntimeObject): Execution<void> {
-      visual.assertIsNotNull()
-      position.assertIsNotNull()
-
-      const visuals = self.get('visuals')?.innerCollection
-      if (!visuals) self.set('visuals', yield* this.list(visual))
-      else {
-        if(visuals.includes(visual)) throw new TypeError(visual.module.fullyQualifiedName())
-        visuals.push(visual)
-      }
-
-      visual.set('position', position)
-    },
-
     *addVisualCharacter(_self: RuntimeObject, visual: RuntimeObject): Execution<RuntimeValue> {
       return yield* this.send('addVisualCharacter', this.object('wollok.gameMirror.gameMirror')!, visual)
-    },
-
-    *addVisualCharacterIn(_self: RuntimeObject, visual: RuntimeObject, position: RuntimeObject): Execution<RuntimeValue> {
-      return yield* this.send('addVisualCharacterIn', this.object('wollok.gameMirror.gameMirror')!, visual, position)
     },
 
     *removeVisual(self: RuntimeObject, visual: RuntimeObject): Execution<void> {


### PR DESCRIPTION
Los siguientes métodos van a ser deprecados en base a lo acordado en [este issue](https://github.com/uqbar-project/wollok-language/issues/57).

game.addVisualIn(obj,pos)
game.addVisualCharacterIn()
position.drawElement(e)
position.drawCharacter(e)

Para conocer la posición de un visual lo que haremos será enviar el mensaje `position()`.

Related: [PR wollok-run-client](https://github.com/uqbar-project/wollok-run-client/pull/66), [PR wollok-language](https://github.com/uqbar-project/wollok-language/pull/111)