### PR TITLE
Fix imports - avoid cyclic loop

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,4 +1,3 @@
-import { List } from './model'
 export const keys = Object.keys as <T>(o: T) => (Extract<keyof T, string>)[]
 
 export const last = <T>(xs: ReadonlyArray<T>): T | undefined => xs[xs.length - 1]
@@ -58,6 +57,8 @@ export const hash = (str: string): number => {
   }
   return hashValue
 }
+
+export type List<T> = ReadonlyArray<T>
 
 export const isEmpty = <T>(value: List<T> | undefined): boolean => !notEmpty(value)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import link from './linker'
-import { Environment, fromJSON, List } from './model'
+import { Environment } from './model'
+import { List } from '../src/extensions'
+import { fromJSON } from '../src/jsonUtils'
 import * as parse from './parser'
 import validate from './validator'
 import WRE from './wre/wre.json'

--- a/src/interpreter/runtimeModel.ts
+++ b/src/interpreter/runtimeModel.ts
@@ -1,5 +1,5 @@
-import { Environment, is, Method, Module, Name, Node, Variable, Singleton, Expression, List, Id, Body, Assignment, Return, Reference, Self, Literal, LiteralValue, New, Send, Super, If, Try, Throw, Test, Program } from '../model'
-import { get, last } from '../extensions'
+import { Environment, is, Method, Module, Name, Node, Variable, Singleton, Expression, Id, Body, Assignment, Return, Reference, Self, Literal, LiteralValue, New, Send, Super, If, Try, Throw, Test, Program } from '../model'
+import { get, last, List } from '../extensions'
 import { v4 as uuid } from 'uuid'
 import { Interpreter } from './interpreter'
 

--- a/src/jsonUtils.ts
+++ b/src/jsonUtils.ts
@@ -1,0 +1,19 @@
+import { isNode, Kind } from './model'
+import { mapObject } from './extensions'
+import * as Models from './model'
+
+const { isArray } = Array
+
+export function fromJSON<T>(json: any): T {
+  const propagate = (data: any) => {
+    if (isNode(data)) {
+      const payload = mapObject(fromJSON, data) as {kind: Kind}
+      const constructor = Models[payload.kind] as any
+      return new constructor(payload)
+    }
+    if (isArray(data)) return data.map(fromJSON)
+    if (data instanceof Object) return mapObject(fromJSON, data)
+    return data
+  }
+  return propagate(json) as T
+}

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from 'uuid'
 import { Id } from '.'
-import { divideOn } from './extensions'
-import { Entity, Environment, List, Name, Node, Package, Scope, Problem, Reference } from './model'
+import { divideOn, List } from './extensions'
+import { Entity, Environment, Name, Node, Package, Scope, Problem, Reference } from './model'
 const { assign } = Object
 
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,13 +1,11 @@
-import { last, mapObject, notEmpty } from './extensions'
+import { last, List, mapObject, notEmpty } from './extensions'
 import { lazy, cached } from './decorators'
-import * as Models from './model'
 
 const { isArray } = Array
 const { entries, values, assign } = Object
 
 export type Name = string
 export type Id = string
-export type List<T> = ReadonlyArray<T>
 
 export interface Scope {
   resolve<N extends Node>(qualifiedName: Name, allowLookup?: boolean): N | undefined
@@ -66,20 +64,6 @@ export const isNode = (obj: any): obj is Node => !!(obj && obj.kind)
 
 export const is = <Q extends Kind | Category>(kindOrCategory: Q) => (node: Node): node is NodeOfKindOrCategory<Q> =>
   node.is(kindOrCategory)
-
-export function fromJSON<T>(json: any): T {
-  const propagate = (data: any) => {
-    if (isNode(data)) {
-      const payload = mapObject(fromJSON, data) as {kind: Kind}
-      const constructor = Models[payload.kind] as any
-      return new constructor(payload)
-    }
-    if (isArray(data)) return data.map(fromJSON)
-    if (data instanceof Object) return mapObject(fromJSON, data)
-    return data
-  }
-  return propagate(json) as T
-}
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 // KINDS

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,8 +1,8 @@
 import Parsimmon, { takeWhile, alt as alt_parser, index, lazy, makeSuccess, notFollowedBy, of, Parser, regex, seq, seqObj, string, whitespace, any, Index } from 'parsimmon'
 import { basename, dirname } from 'path'
 import unraw from 'unraw'
-import { SourceIndex, Assignment as AssignmentNode, Body as BodyNode, Catch as CatchNode, Class as ClassNode, Describe as DescribeNode, Entity as EntityNode, Expression as ExpressionNode, Field as FieldNode, If as IfNode, Import as ImportNode, List, Literal as LiteralNode, Method as MethodNode, Mixin as MixinNode, Name, NamedArgument as NamedArgumentNode, New as NewNode, Node, Package as PackageNode, Parameter as ParameterNode, Program as ProgramNode, Reference as ReferenceNode, Return as ReturnNode, Self as SelfNode, Send as SendNode, Sentence as SentenceNode, Singleton as SingletonNode, Super as SuperNode, Test as TestNode, Throw as ThrowNode, Try as TryNode, Variable as VariableNode, Problem, SourceMap, Closure as ClosureNode, ParameterizedType as ParameterizedTypeNode, LiteralValue, Annotation, is } from './model'
-import { mapObject, discriminate } from './extensions'
+import { SourceIndex, Assignment as AssignmentNode, Body as BodyNode, Catch as CatchNode, Class as ClassNode, Describe as DescribeNode, Entity as EntityNode, Expression as ExpressionNode, Field as FieldNode, If as IfNode, Import as ImportNode, Literal as LiteralNode, Method as MethodNode, Mixin as MixinNode, Name, NamedArgument as NamedArgumentNode, New as NewNode, Node, Package as PackageNode, Parameter as ParameterNode, Program as ProgramNode, Reference as ReferenceNode, Return as ReturnNode, Self as SelfNode, Send as SendNode, Sentence as SentenceNode, Singleton as SingletonNode, Super as SuperNode, Test as TestNode, Throw as ThrowNode, Try as TryNode, Variable as VariableNode, Problem, SourceMap, Closure as ClosureNode, ParameterizedType as ParameterizedTypeNode, LiteralValue, Annotation, is } from './model'
+import { List, mapObject, discriminate } from './extensions'
 
 // TODO: Use description in lazy() for better errors
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -18,10 +18,11 @@
 // - Level could be different for the same Expectation on different nodes
 // - Problem could know how to convert to string, receiving the interpolation function (so it can be translated). This could let us avoid having parameters.
 // - Good default for simple problems, but with a config object for more complex, so we know what is each parameter
+import { count, duplicates, isEmpty, last, List, notEmpty } from './extensions'
 // - Unified problem type
-import { SourceIndex, Class, Describe, If, Mixin, Module, NamedArgument, Self, Sentence, Test } from './model'
-import { Assignment, Body, Entity, Expression, Field, is, Kind, List, Method, New, Node, NodeOfKind, Parameter, Send, Singleton, SourceMap, Try, Variable } from './model'
-import { count, duplicates, isEmpty, last, notEmpty } from './extensions'
+import { Assignment, Body, Class, Describe, Entity, Expression, Field, If, is, Kind, Method, Mixin,
+  Module, NamedArgument, New, Node, NodeOfKind, Parameter, Self, Send, Sentence, Singleton,
+  SourceIndex, SourceMap, Test, Try, Variable } from './model'
 
 const { entries } = Object
 

--- a/src/wre/lang.ts
+++ b/src/wre/lang.ts
@@ -1,6 +1,6 @@
-import { isEmpty, hash } from '../extensions'
+import { isEmpty, hash, List } from '../extensions'
 import { Natives, Evaluation, RuntimeObject, Execution, RuntimeValue } from '../interpreter/runtimeModel'
-import { Class, List, Node } from '../model'
+import { Class, Node } from '../model'
 
 const { abs, ceil, random, floor, round } = Math
 const { isInteger } = Number

--- a/src/wre/lang.ts
+++ b/src/wre/lang.ts
@@ -1,5 +1,5 @@
-import { isEmpty, hash, List } from '../extensions'
-import { Natives, Evaluation, RuntimeObject, Execution, RuntimeValue } from '../interpreter/runtimeModel'
+import { hash, isEmpty, List } from '../extensions'
+import { Evaluation, Execution, Natives, RuntimeObject, RuntimeValue } from '../interpreter/runtimeModel'
 import { Class, Node } from '../model'
 
 const { abs, ceil, random, floor, round } = Math

--- a/test/assertions.ts
+++ b/test/assertions.ts
@@ -1,6 +1,7 @@
 import { formatError, Parser } from 'parsimmon'
 import link from '../src/linker'
-import { Name, Node, Package, Reference, List, Environment as EnvironmentType, Environment } from '../src/model'
+import { Name, Node, Package, Reference, Environment as EnvironmentType, Environment } from '../src/model'
+import { List } from '../src/extensions'
 import { Validation } from '../src/validator'
 import { ParseError } from '../src/parser'
 import globby from 'globby'

--- a/test/linker.test.ts
+++ b/test/linker.test.ts
@@ -1,5 +1,6 @@
 import { expect, should, use } from 'chai'
-import { Body, Class, Closure, Describe, Environment, Field, fromJSON, Import, Method, Mixin, NamedArgument, Package, Parameter, ParameterizedType, Reference, Return, Singleton, Test, Variable } from '../src/model'
+import { Body, Class, Closure, Describe, Environment, Field, Import, Method, Mixin, NamedArgument, Package, Parameter, ParameterizedType, Reference, Return, Singleton, Test, Variable } from '../src/model'
+import { fromJSON } from '../src/jsonUtils'
 import link, { LinkError } from '../src/linker'
 import wre from '../src/wre/wre.json'
 import { linkerAssertions } from './assertions'

--- a/test/validator-deprecated.test.ts
+++ b/test/validator-deprecated.test.ts
@@ -550,7 +550,7 @@ describe('Wollok Validator', () => {
     describe('Test is not empty', () => {
       const environment = link([
         WRE,
-        new Package({ name: 'p', members: [new Test({ name: 't', body: new Body({ sourceMap: { start: { offset: 0, line: 0, column: 0 }, end: { offset: 0, line: 0, column: 0 } } }) })] }
+        new Package({ name: 'p', members: [new Test({ name: 't', body: new Body({ sourceMap: { covers: () => true, start: { offset: 0, line: 0, column: 0 }, end: { offset: 0, line: 0, column: 0 } } }) })] }
         )])
 
 

--- a/test/wtest.ts
+++ b/test/wtest.ts
@@ -1,6 +1,7 @@
 import { basename } from 'path'
 import yargs from 'yargs'
-import { List, Node } from '../src/model'
+import { Node } from '../src/model'
+import { List } from '../src/extensions'
 import { buildEnvironment } from './assertions'
 import interpret, { Interpreter } from '../src/interpreter/interpreter'
 import natives from '../src/wre/wre.natives'


### PR DESCRIPTION
Ahí estuve metiendo mano para evitar que entremos en loop al hacer los imports. Uno de los temas que había era que `extensions.ts` importaba List de `model.ts` y a su vez `model.ts` necesitaba cosas de `extensions.ts`.
