### PR TITLE
Agrego 'wollok' a la lista de palabras reservadas

### DIFF
--- a/src/validator.ts
+++ b/src/validator.ts
@@ -663,7 +663,7 @@ const unusedVariable = (node: Field) => {
 const usesReservedWords = (node: Class | Singleton | Variable | Field | Parameter) => {
   const parent = node.ancestors().find(ancestor => ancestor.is('Package')) as Package | undefined
   const wordsReserved = LIBRARY_PACKAGES.flatMap(libPackage => node.environment.getNodeByFQN<Package>(libPackage).members.map(_ => _.name))
-  wordsReserved.push('wollok', 'Wollok')
+  wordsReserved.push('wollok')
   return !!parent && !parent.fullyQualifiedName().includes('wollok.') && wordsReserved.includes(node.name)
 }
 


### PR DESCRIPTION
Este PR viene del error encontrado en wollok-ts-cli: [Error por constante llamada wollok #15](https://github.com/uqbar-project/wollok-ts-cli/issues/15)

Fixes https://github.com/uqbar-project/wollok-ts-cli/issues/15

El otro día en la reunión hablamos si la palabra 'wollok' debería ser una palabra reservada, `shouldNotUseReservedWords` que lanza warning o una keyword `nameShouldNotBeKeyword` que lanza un error.

Mirando los test de wollok-languaje entre [shouldNotUseReservedWords](https://github.com/uqbar-project/wollok-language/blob/master/test/validations/shouldNotUseReservedWords.wlk) y [nameShouldNotBeKeyword](https://github.com/uqbar-project/wollok-language/blob/master/test/validations/nameShouldNotBeKeyword.wpgm)

Llegamos a la conclusión de que las palabras 'keyword' son las palabras que pertenecen al lenguaje wollok y las palabras reservadas son aquellas que no se deben usar porque son importantes pero no son propias del lenguaje wollok.

Por eso nos pareció que la palabra wollok debería ser una palabra reservada.

Habría que agregar estos test a wollok-languaje:
```wollok
@Expect(code = "shouldNotUseReservedWords", value = "warning")
class Wollok {}

@Expect(code = "shouldNotUseReservedWords", value = "warning")
const wollok =11
```

@nscarcella 
- lo podés mirar a ver si estamos en lo correcto?? 😄 😄
- está bien que se agregue 'wollok' y 'Wollok' a la lista? 

 Gracias!!!
@asanzo 

