### PR TITLE
kindName now responds an Object and not FQN

### DIFF
--- a/src/wre/lang.ts
+++ b/src/wre/lang.ts
@@ -35,7 +35,14 @@ const lang: Natives = {
     },
 
     *kindName(self: RuntimeObject): Execution<RuntimeValue> {
-      return yield* this.reify(self.module.fullyQualifiedName())
+      const onlyModuleName = self.module.fullyQualifiedName().split(".").pop()!
+      const aOrAn = onlyModuleName.match(/^[AEIOUaeiou]+.*/) ? "an" : "a"
+
+      const kindName = 
+        self.module.kind === "Singleton" && self.module.name ||
+        aOrAn + " " + onlyModuleName
+
+      return yield* this.reify(kindName)
     },
 
     *className(self: RuntimeObject): Execution<RuntimeValue> {

--- a/src/wre/lang.ts
+++ b/src/wre/lang.ts
@@ -35,12 +35,12 @@ const lang: Natives = {
     },
 
     *kindName(self: RuntimeObject): Execution<RuntimeValue> {
-      const onlyModuleName = self.module.fullyQualifiedName().split(".").pop()!
-      const aOrAn = onlyModuleName.match(/^[AEIOUaeiou]+.*/) ? "an" : "a"
+      const onlyModuleName = self.module.fullyQualifiedName().split('.').pop()!
+      const aOrAn = onlyModuleName.match(/^[AEIOUaeiou]+.*/) ? 'an' : 'a'
 
-      const kindName = 
-        self.module.kind === "Singleton" && self.module.name ||
-        aOrAn + " " + onlyModuleName
+      const kindName =
+        self.module.kind === 'Singleton' && self.module.name ||
+        aOrAn + ' ' + onlyModuleName
 
       return yield* this.reify(kindName)
     },


### PR DESCRIPTION
Bueno, reavivo la discusión de https://github.com/uqbar-project/wollok-language/issues/140 con un PR cagón.

![imagen](https://user-images.githubusercontent.com/5421992/196014607-89344f45-0650-4e13-a5bb-f988a28cddca.png)
![imagen](https://user-images.githubusercontent.com/5421992/196014609-61bddb32-2b07-4568-8c04-5b1e1f4b706e.png)

En un lenguaje de programación industrial, compro que el fullyQualifiedName es definitivamente una mejor decisión a la hora de imprimir por consola un módulo.

Pero:
- en el tamaño que van a tener los proyectos en la facu, no debería ser tan problemático desambiguar alla Smaltalk.
- me preocupa que ver "aves.Golondrina" contribuya a la confusión que hoy tienen de **diferenciar instancia de clase**. 
- no me gustaba como quedaba "a aves.Golondrina", por eso maté el FQN.
- En [la doc de kindName](https://github.com/uqbar-project/wollok-language/blob/master/src/wollok/lang.wlk#L122-L130) decía que devuelve algo de este estilo.

----------------------------------

Sobre la implementación, 

- Se me ocurrió meter mensajes polimórficos en el Model, en los Modules, pero me dio un poco de cosa poner comportamiento de implementación de natives en el modelo de nodos. Y tampoco me parecía que correspondía en runtimeModel, porque resolvía otros problemas. Así que quedó nomás el typecheck por Singleton.
- Meter tests (que deberían ser en wollok-language como un sanity test) me pareció un poco fuerte, así que no hice ese PR allá. 