### PR TITLE
Fix relink

### DIFF
--- a/src/linker.ts
+++ b/src/linker.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from 'uuid'
 import { Id, Import, Sentence } from '.'
 import { divideOn, List } from './extensions'
-import { BaseProblem, Entity, Environment, Level, Name, Node, Package, Scope, Reference, SourceMap } from './model'
+import { BaseProblem, Entity, Environment, Level, Name, Node, Package, Scope, Reference, SourceMap, is } from './model'
 const { assign } = Object
 
 
@@ -23,17 +23,21 @@ const fail = (code: Name) => (node: Reference<Node>) =>
 // MERGING
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 
-const mergePackage = (members: List<Entity>, isolated: Entity): List<Entity> => {
-  if (!isolated.is('Package')) return [...members.filter(({ name }) => name !== isolated.name), isolated]
+const mergePackage = (members: List<Package>, isolated: Package): List<Package> => {
   const existent = members.find((member: Entity): member is Package =>
     member.is('Package') && member.name === isolated.name)
   return existent
     ? [
       ...members.filter(member => member !== existent),
       existent.copy({
-        members: isolated.members.reduce(mergePackage, existent.members),
+        members: [
+          ...isolated.members
+            .filter(is('Package'))
+            .reduce(mergePackage, existent.members.filter(is('Package'))),
+          ...isolated.members.filter(m => !m.is('Package')),
+        ],
         problems: isolated.problems,
-        imports: [...isolated.imports],
+        imports: isolated.imports,
       }) as Package,
     ]
     : [...members, isolated]

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -33,7 +33,7 @@ const mergePackage = (members: List<Entity>, isolated: Entity): List<Entity> => 
       existent.copy({
         members: isolated.members.reduce(mergePackage, existent.members),
         problems: isolated.problems,
-        imports: [ ...isolated.imports ],
+        imports: [...isolated.imports],
       }) as Package,
     ]
     : [...members, isolated]

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -32,12 +32,8 @@ const mergePackage = (members: List<Entity>, isolated: Entity): List<Entity> => 
       ...members.filter(member => member !== existent),
       existent.copy({
         members: isolated.members.reduce(mergePackage, existent.members),
-        imports: [
-          ...existent.imports,
-          ...isolated.imports.filter(node => !existent.imports.some(other =>
-            node.entity.name === other.entity.name && node.isGeneric === other.isGeneric
-          )),
-        ],
+        problems: isolated.problems,
+        imports: [ ...isolated.imports ],
       }) as Package,
     ]
     : [...members, isolated]

--- a/test/linker.test.ts
+++ b/test/linker.test.ts
@@ -182,9 +182,8 @@ describe('Wollok linker', () => {
       nextEnvironment.getNodeByFQN('p.Y').should.equal(Y)
     })
 
-    it('should merge package imports', () => {
+    it('should replace merged packages imports', () => {
       [
-        ...WRE.members,
         new Package({
           name: 'A',
           imports: [
@@ -203,12 +202,10 @@ describe('Wollok linker', () => {
         new Package({ name: 'C' }),
         new Package({ name: 'D' }),
       ].should.be.linkedInto([
-        ...WRE.members,
         new Package({
           name: 'A',
           imports: [
             new Import({ isGeneric: true, entity: new Reference({ name: 'B' }) }),
-            new Import({ isGeneric: true, entity: new Reference({ name: 'C' }) }),
             new Import({ isGeneric: true, entity: new Reference({ name: 'D' }) }),
           ],
         }),
@@ -218,7 +215,20 @@ describe('Wollok linker', () => {
       ])
     })
 
+    it('should replace merged packages problems', () => {
+      [
+        new Package({
+          name: 'A',
+          problems: [{ code: 'ERROR', level: 'error', values: [] }],
+        }),
+        new Package({ name: 'A', }),
+      ].should.be.linkedInto([
+        new Package({ name: 'A', }),
+      ])
+    })
+
   })
+
 
   it('should assign an id to all nodes', () => {
     const environment = link([
@@ -247,7 +257,7 @@ describe('Wollok linker', () => {
           members: [
             new Class({
               name: 'C',
-              supertypes:[new ParameterizedType({ reference: new Reference({ name: 'wollok.lang.Object' }) })],
+              supertypes: [new ParameterizedType({ reference: new Reference({ name: 'wollok.lang.Object' }) })],
               members: [
                 new Field({ name: 'f', isConstant: true, value: new Reference({ name: 'C' }) }),
                 new Field({ name: 'g', isConstant: true, value: new Reference({ name: 'p' }) }),

--- a/test/linker.test.ts
+++ b/test/linker.test.ts
@@ -221,9 +221,9 @@ describe('Wollok linker', () => {
           name: 'A',
           problems: [{ code: 'ERROR', level: 'error', values: [] }],
         }),
-        new Package({ name: 'A', }),
+        new Package({ name: 'A' }),
       ].should.be.linkedInto([
-        new Package({ name: 'A', }),
+        new Package({ name: 'A' }),
       ])
     })
 

--- a/test/linker.test.ts
+++ b/test/linker.test.ts
@@ -79,7 +79,6 @@ describe('Wollok linker', () => {
         new Package({
           name: 'A',
           members: [
-            new Class({ name: 'X' }),
             new Class({ name: 'Y' }),
           ],
         }),
@@ -92,9 +91,8 @@ describe('Wollok linker', () => {
       ])
     })
 
-    it('should recursively merge same name packages into a single package', () => {
+    it('should recursively override same name packages with new package', () => {
       [
-        ...WRE.members,
         new Package({
           name: 'A',
           members: [
@@ -104,6 +102,7 @@ describe('Wollok linker', () => {
                 new Class({ name: 'X' }),
               ],
             }),
+            new Package({ name: 'C' }),
           ],
         }),
         new Package({
@@ -117,20 +116,21 @@ describe('Wollok linker', () => {
             }),
           ],
         }),
+        ...WRE.members,
       ].should.be.linkedInto([
-        ...WRE.members,
         new Package({
           name: 'A',
           members: [
+            new Package({ name: 'C' }),
             new Package({
               name: 'B',
               members: [
-                new Class({ name: 'X' }),
                 new Class({ name: 'Y' }),
               ],
             }),
           ],
         }),
+        ...WRE.members,
       ])
     })
 
@@ -176,8 +176,9 @@ describe('Wollok linker', () => {
       ], baseEnvironment)
 
       const p = nextEnvironment.members[1]
-      const Y = p.members[1]
+      const Y = p.members[0]
 
+      p.members.should.have.lengthOf(1)
       nextEnvironment.getNodeByFQN('p').should.equal(p)
       nextEnvironment.getNodeByFQN('p.Y').should.equal(Y)
     })


### PR DESCRIPTION
Relinkeo de un Environment:  significa hacer un `link` de packages pasando un base-environment. El problema con esto es cuando colisionan los packages: o sea, pasás un nuevo package con el mismo nombre que uno viejo (o que de esa lista que se le pasa haya dos packages con el mismo nombre).

Esa lógica implica un merge de entidades, la idea con esto es que el uso del environment pueda ser **incremental**. Esto está pensado para un IDE en donde las ediciones son dentro de un solo archivo (que se representa como un package!) y solamente tener que pasear ese archivo y poder _integrarlo_ al resto del Environment.

Había un problema en este **relinkeo** que evitaba "borrar" entidades, por ejemplo quiero _renombrar_ la clase de un objeto, la vieja clase nunca se borraba. Esto es porque siempre se buscaba _mergear_ lo viejo y lo nuevo, y era difícil _sobreescribir_ algo.

Esto impactaba en el IDE: si en un momento tenías un error en alguna entidad, **nunca podías arreglarlos**.

Ahora cambié esa lógica para que **sobreescriba** lo que está dentro de un package, pero manteniendo el mergeo de packages (interiores). O sea, en caso de colisión entre un package viejo y uno :
- Todas las entidades (que no son packages) de un Package son reemplazadas por la del nuevo (que tampoco son packages)
- Para las entidades que son packages, se mergea (recursivo) con el nuevo package

Esta recursividad de packages es importante porque los directorios también se representan como packages. 
Eso significa que un proyecto:
```
BASE
|- aves 
   |- pepita.wlk (define object pepita)
|- entrenadores
   |- pepe.wlk (define object pepe)
```
Tiene como modelo:
```
Environment([
  Package('aves', [
    Package('pepita', [
      Object('pepita')
    ])
  ]),
  Package('entrenadores', [
    Package('pepe', [
      Object('pepe')
    ])
  ])
])
```

Entonces si hacemos un cambio en el objeto `pepita`, se re-linkearía con:

```
  Package('aves', [
    Package('pepita', [
      Object('pepita') // nueva versión
    ])
  ])
```

Y lo que quedaría haría que solamente se _sobreescriba_ la definición del objeto pepita sin pisar a pepe.