### PR TITLE
filter node children

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -255,6 +255,12 @@ abstract class $Node {
     return applyReduce(initial, this)
   }
 
+  filter(this: Node, cond: (node: Node, parent?: Node) => boolean): Node[] {
+    return this.reduce<Node[]>((acum, node, parent) => {
+      return cond(node, parent) ? acum.concat(node) : acum
+    }, [])
+  }
+
   isGlobal() { return this.parent.is('Package') }
 }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -255,9 +255,9 @@ abstract class $Node {
     return applyReduce(initial, this)
   }
 
-  filter(this: Node, cond: (node: Node, parent?: Node) => boolean): Node[] {
+  filter(this: Node, closure: (node: Node, parent?: Node) => boolean): Node[] {
     return this.reduce<Node[]>((acum, node, parent) => {
-      return cond(node, parent) ? acum.concat(node) : acum
+      return closure(node, parent) ? acum.concat(node) : acum
     }, [])
   }
 


### PR DESCRIPTION
En el desarrollo del lsp [surgio un filter](https://github.com/uqbar-project/wollok-lsp-ide/pull/43#discussion_r1021393269), tenerlo en el mismo lugar que el `forEach` parecia la opcion mas correcta.