### PR TITLE
body should recover from malformed sentence

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -175,7 +175,7 @@ export const NamedArgument: Parser<NamedArgumentNode> = node(NamedArgumentNode)(
 )
 
 export const Body: Parser<BodyNode> = node(BodyNode)(() =>
-  obj({ sentences: Sentence.skip(__).many() }).wrap(key('{'), key('}'))
+  obj({ sentences: alt(Sentence.skip(__), sentenceError).many() }).wrap(key('{'), key('}')).map(recover)
 )
 
 const inlineableBody: Parser<BodyNode> = Body.or(
@@ -330,6 +330,8 @@ export const Method: Parser<MethodNode> = node(MethodNode)(() =>
 // ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 // SENTENCES
 // ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+const sentenceError = error('malformedSentence')()
 
 export const Sentence: Parser<SentenceNode> = lazy('sentence', () => alt(Variable, Return, Assignment, Expression))
 

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1502,9 +1502,24 @@ describe('Wollok parser', () => {
       it('should not parse development with closures of native methods', () => {
         'method m(p,q) native { }'.should.not.be.parsedBy(parser)
       })
-
     })
 
+  })
+
+  describe('Body', () => {
+    const parser = parse.Body
+
+    it('should recover from malformed sentence', () => {
+      `{
+            felicidad.
+      }`.should.be.parsedBy(parser)
+        .recoveringFrom('malformedSentence', 23, 24)
+        .into( new Body({
+          sentences: [
+            new Reference({ name: 'felicidad' }),
+          ],
+        }))
+    })
   })
 
   describe('Sentences', () => {


### PR DESCRIPTION
Closes #139 

Ahora `pepita`:
```wlk
object pepita {
    var peso = 0

    method come(comida) {
        peso = comida.
    }
}
```

Se parsearia a:

```js
{
  name: 'pepita',
  kind: 'Singleton',
  members: [
    { name: 'peso', kind: 'Field' },
    { 
      name: 'come', 
      parameters: [ { name: 'comida', kind: 'Parameter' } ], 
      body: {
        sentences: [
          { 
            kind: 'Assignment', 
            variable: { name: 'peso', kind: 'Reference' }, 
            value: { kind: 'Reference', name: 'comida' } // dejando afuera el '.'
          },
        ],
        problems: [ { code: 'malformedSentence' } ]
      }  
    }
  ]
}
```