### PR TITLE
Update wollok version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wollok-ts",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wollok-ts",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
         "@types/parsimmon": "^1.10.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wollok-ts",
   "version": "4.0.2",
-  "wollokVersion": "3.1.5",
+  "wollokVersion": "3.1.6",
   "description": "TypeScript based Wollok language implementation",
   "repository": "https://github.com/uqbar-project/wollok-ts",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wollok-ts",
   "version": "4.0.2",
-  "wollokVersion": "3.1.3",
+  "wollokVersion": "3.1.5",
   "description": "TypeScript based Wollok language implementation",
   "repository": "https://github.com/uqbar-project/wollok-ts",
   "license": "MIT",

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -73,6 +73,8 @@ export class LocalScope implements Scope {
   }
 
   include(...others: Scope[]): void { this.includedScopes.push(...others) }
+
+  localContributions(): [Name, Node][] { return [...this.contributions.entries()] }
 }
 
 
@@ -113,7 +115,7 @@ const assignScopes = (environment: Environment) => {
         const entity = node.parent.scope.resolve<Entity>(imported.entity.name)
 
         if(entity) node.scope.include(imported.isGeneric
-          ? entity.scope
+          ? new LocalScope(undefined, ...entity.scope.localContributions())
           : new LocalScope(undefined, [entity.name!, entity])
         )
       }

--- a/src/model.ts
+++ b/src/model.ts
@@ -12,6 +12,7 @@ export interface Scope {
   resolve<N extends Node>(qualifiedName: Name, allowLookup?: boolean): N | undefined
   include(...others: Scope[]): void
   register(...contributions: [Name, Node][]): void
+  localContributions(): [Name, Node][]
 }
 
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -181,6 +181,7 @@ export const shouldOnlyInheritFromMixin = error<Mixin>(node => node.supertypes.e
   const target = parent.reference.target
   return !target || target.is(Mixin)
 }))
+
 export const shouldUseOverrideKeyword = warning<Method>(node =>
   node.isOverride || !superclassMethod(node)
 )


### PR DESCRIPTION
Se updatea la versión de Wollok, estaba apuntando a una vieja donde faltaban los últimos tests que agregamos a partir de las pruebas con el LSP.

Eso se había roto después de migrar de Typescript, ahí recuperé los cambios. 
También con esta versión detectamos problemas con imports circulares.