### PR TITLE
Validations: parser + attribute names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wollok-ts",
   "version": "4.0.4",
-  "wollokVersion": "3.1.7",
+  "wollokVersion": "3.1.8",
   "description": "TypeScript based Wollok language implementation",
   "repository": "https://github.com/uqbar-project/wollok-ts",
   "license": "MIT",

--- a/src/model.ts
+++ b/src/model.ts
@@ -41,6 +41,7 @@ export class SourceMap {
 
   toString(): string { return `[${this.start}, ${this.end}]` }
   covers(offset: number): boolean { return this.start.offset <= offset && this.end.offset >= offset }
+  includes(other: SourceMap): boolean { return this.start.offset <= other.start.offset && this.end.offset >= other.end.offset }
 }
 
 export class Annotation {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -780,7 +780,7 @@ const validationsByKind = (node: Node): Record<string, Validation<any>> => match
 export default (target: Node): List<Problem> => target.reduce<Problem[]>((found, node) => {
   return [
     ...found,
-    ...node.problems?.map(({ code }) => ({ code, level: 'error', node, values: [], source: node.sourceMap } as const)) ?? [],
+    ...node.problems?.map(({ code, sourceMap, level, values }) => ({ code, level, node, values, sourceMap: sourceMap ?? node.sourceMap } as Problem)  ) ?? [],
     ...entries(validationsByKind(node))
       .map(([code, validation]) => validation(node, code)!)
       .filter(result => result !== null),

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -20,11 +20,9 @@
 // - Good default for simple problems, but with a config object for more complex, so we know what is each parameter
 import { count, TypeDefinition, duplicates, is, isEmpty, last, List, match, notEmpty, when } from './extensions'
 // - Unified problem type
-import {
-  Assignment, Body, Catch, Class, Code, Describe, Entity, Expression, Field, If, Import,
+import { Assignment, Body, Catch, Class, Code, Describe, Entity, Expression, Field, If, Import,
   Level, Literal, Method, Mixin, Module, NamedArgument, New, Node, Package, Parameter, ParameterizedType, Problem,
-  Program, Reference, Return, Self, Send, Sentence, Singleton, SourceIndex, SourceMap, Super, Test, Throw, Try, Variable
-} from './model'
+  Program, Reference, Return, Self, Send, Sentence, Singleton, SourceIndex, SourceMap, Super, Test, Throw, Try, Variable } from './model'
 
 const { entries } = Object
 
@@ -118,7 +116,7 @@ export const nameShouldBeginWithLowercase = nameMatches(/^[a-z_<]/)
 
 export const nameShouldNotBeKeyword = error<Entity | Parameter | Variable | Field | Method>(node =>
   !KEYWORDS.includes(node.name || ''),
-  node => [node.name || ''],
+node => [node.name || ''],
 )
 
 export const inlineSingletonShouldBeAnonymous = error<Singleton>(
@@ -402,7 +400,7 @@ export const shouldUseConditionalExpression = warning<If>(node => {
     ![true, false].includes(thenValue) ||
     thenValue === elseValue) && (!nextSentence ||
       ![true, false].includes(valueFor(nextSentence))
-    )
+  )
 })
 
 

--- a/test/game.test.ts
+++ b/test/game.test.ts
@@ -14,7 +14,7 @@ describe('Wollok Game', () => {
   describe('actions', () => {
 
     let environment: Environment
-    let interpreter: Interpreter 
+    let interpreter: Interpreter
 
 
     before(async () => {

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1445,7 +1445,7 @@ describe('Wollok parser', () => {
       })
 
       it('should parse annotated subnodes within expression bodies', () => {
-        'method m() = @A(x = 1) 5'.should.be.parsedBy(parser).into(
+        'method m() = (@A(x = 1) 5)'.should.be.parsedBy(parser).into(
           new Method({
             name: 'm', body: new Body({
               sentences: [

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -19,9 +19,9 @@ describe('Wollok Validations', () => {
   }))
   const environment = buildEnvironment(files)
 
-  const matchesExpectation = (problem: Problem, expected: Annotation) => {
+  const matchesExpectation = (problem: Problem, annotatedNode: Node, expected: Annotation) => {
     const code = expected.args.get('code')!
-    return problem.code === code && problem.sourceMap?.toString() === problem.node.sourceMap?.toString()
+    return problem.code === code && annotatedNode.sourceMap?.includes(problem.sourceMap!)
   }
 
   const errorLocation = (node: Node | Problem): string => `${node.sourceMap}`
@@ -54,11 +54,11 @@ describe('Wollok Validations', () => {
 
           if (!code) fail('Missing required "code" argument in @Expect annotation')
 
-          const errors = problems.filter(problem => !matchesExpectation(problem, expectedProblem))
+          const errors = problems.filter(problem => !matchesExpectation(problem, node, expectedProblem))
           if (notEmpty(errors))
             fail(`File contains errors: ${errors.map((_error) => _error.code + ' at ' + errorLocation(_error)).join(', ')}`)
 
-          const effectiveProblem = problems.find(problem => matchesExpectation(problem, expectedProblem))
+          const effectiveProblem = problems.find(problem => matchesExpectation(problem, node, expectedProblem))
           if (!effectiveProblem)
             fail(`Missing expected ${code} ${level ?? 'problem'} at ${errorLocation(node)}`)
 
@@ -74,7 +74,7 @@ describe('Wollok Validations', () => {
         }
 
         for (const problem of problems) {
-          if (!expectedProblems.some(expectedProblem => matchesExpectation(problem, expectedProblem)))
+          if (!expectedProblems.some(expectedProblem => matchesExpectation(problem, node, expectedProblem)))
             fail(`Unexpected ${problem.code} ${problem.level} at ${errorLocation(node)}`)
         }
       })

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -4,9 +4,9 @@ import { readFileSync } from 'fs'
 import globby from 'globby'
 import { join } from 'path'
 import { Annotation, buildEnvironment } from '../src'
-import { notEmpty } from '../src/extensions'
+import { List, notEmpty } from '../src/extensions'
 import validate from '../src/validator'
-import { Node, Problem } from './../src/model'
+import { Class, Literal, Node, Problem, Reference } from './../src/model'
 
 const TESTS_PATH = 'language/test/validations'
 
@@ -50,6 +50,7 @@ describe('Wollok Validations', () => {
         for (const expectedProblem of expectedProblems) {
           const code = expectedProblem.args.get('code')!
           const level = expectedProblem.args.get('level')
+          const values = expectedProblem.args.get('values')
 
           if (!code) fail('Missing required "code" argument in @Expect annotation')
 
@@ -64,6 +65,12 @@ describe('Wollok Validations', () => {
 
           if (level && effectiveProblem.level !== level)
             fail(`Expected ${code} to be ${level} but was ${effectiveProblem.level} at ${errorLocation(node)}`)
+
+          if (values) {
+            const stringValues = (values as [Reference<Class>, List<Literal<string>>])[1].map(v => v.value)
+            if (stringValues.join('||') !== effectiveProblem.values.join('||'))
+              fail(`Expected ${code} to have ${JSON.stringify(stringValues)} but was ${JSON.stringify(effectiveProblem.values)} at ${errorLocation(node)}`)
+          }
         }
 
         for (const problem of problems) {


### PR DESCRIPTION
Fix https://github.com/uqbar-project/wollok-lsp-ide/issues/54

- La validación estaba de esa forma para contemplar atributos heredados.
- La dejé solamente para atributos heredados, hice que devolviese `values` con un solo elemento (nombres separados por comas) para que sea traducible (interpolable).
- Agregué otra validación para los Fields de Singletons sin inicializar (o sea, en ese caso, se marca en el atributo en vez de en el objeto).

(Viniendo la screenshot...)


### Tests: https://github.com/uqbar-project/wollok-language/pull/160

### Falta hacer el cambio en las translations del LSP https://github.com/uqbar-project/wollok-lsp-ide/issues/93