### PR TITLE
Expression body parser

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -41,6 +41,7 @@ export class SourceMap {
 
   toString(): string { return `[${this.start}, ${this.end}]` }
   covers(offset: number): boolean { return this.start.offset <= offset && this.end.offset >= offset }
+  includes(other: SourceMap): boolean { return this.start.offset <= other.start.offset && this.end.offset >= other.end.offset }
 }
 
 export class Annotation {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -766,7 +766,7 @@ const validationsByKind = (node: Node): Record<string, Validation<any>> => match
 export default (target: Node): List<Problem> => target.reduce<Problem[]>((found, node) => {
   return [
     ...found,
-    ...node.problems?.map(({ code }) => ({ code, level: 'error', node, values: [], source: node.sourceMap } as const)  ) ?? [],
+    ...node.problems?.map(({ code, sourceMap, level, values }) => ({ code, level, node, values, sourceMap: sourceMap ?? node.sourceMap } as Problem)  ) ?? [],
     ...entries(validationsByKind(node))
       .map(([code, validation]) => validation(node, code)!)
       .filter(result => result !== null),

--- a/test/game.test.ts
+++ b/test/game.test.ts
@@ -14,7 +14,7 @@ describe('Wollok Game', () => {
   describe('actions', () => {
 
     let environment: Environment
-    let interpreter: Interpreter 
+    let interpreter: Interpreter
 
 
     before(async () => {

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1445,7 +1445,7 @@ describe('Wollok parser', () => {
       })
 
       it('should parse annotated subnodes within expression bodies', () => {
-        'method m() = @A(x = 1) 5'.should.be.parsedBy(parser).into(
+        'method m() = (@A(x = 1) 5)'.should.be.parsedBy(parser).into(
           new Method({
             name: 'm', body: new Body({
               sentences: [

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -19,9 +19,9 @@ describe('Wollok Validations', () => {
   }))
   const environment = buildEnvironment(files)
 
-  const matchesExpectation = (problem: Problem, expected: Annotation) => {
+  const matchesExpectation = (problem: Problem, annotatedNode: Node, expected: Annotation) => {
     const code = expected.args.get('code')!
-    return problem.code === code && problem.sourceMap?.toString() === problem.node.sourceMap?.toString()
+    return problem.code === code && annotatedNode.sourceMap?.includes(problem.sourceMap!)
   }
 
   const errorLocation = (node: Node | Problem): string => `${node.sourceMap}`
@@ -53,11 +53,11 @@ describe('Wollok Validations', () => {
 
           if (!code) fail('Missing required "code" argument in @Expect annotation')
 
-          const errors = problems.filter(problem => !matchesExpectation(problem, expectedProblem))
+          const errors = problems.filter(problem => !matchesExpectation(problem, node, expectedProblem))
           if (notEmpty(errors))
             fail(`File contains errors: ${errors.map((_error) => _error.code + ' at ' + errorLocation(_error)).join(', ')}`)
 
-          const effectiveProblem = problems.find(problem => matchesExpectation(problem, expectedProblem))
+          const effectiveProblem = problems.find(problem => matchesExpectation(problem, node, expectedProblem))
           if (!effectiveProblem)
             fail(`Missing expected ${code} ${level ?? 'problem'} at ${errorLocation(node)}`)
 
@@ -67,7 +67,7 @@ describe('Wollok Validations', () => {
         }
 
         for (const problem of problems) {
-          if (!expectedProblems.some(expectedProblem => matchesExpectation(problem, expectedProblem)))
+          if (!expectedProblems.some(expectedProblem => matchesExpectation(problem, node, expectedProblem)))
             fail(`Unexpected ${problem.code} ${problem.level} at ${errorLocation(node)}`)
         }
       })


### PR DESCRIPTION
Fix https://github.com/uqbar-project/wollok-lsp-ide/issues/83
Fix #158 

Ahora los metodos de consulta pueden marcar su "body" como una sentencia malformada

Tambien arregla un typo de las validations que fixea #158 

Tests: https://github.com/uqbar-project/wollok-language/pull/161