### PR TITLE
Filtering wollok base frames from stack trace & adding constants

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,3 @@
+export const WOLLOK_EXTRA_STACK_TRACE_HEADER = 'Derived from TypeScript stack'
+
+export const WOLLOK_BASE_PACKAGE = 'wollok'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,3 @@
 export const WOLLOK_EXTRA_STACK_TRACE_HEADER = 'Derived from TypeScript stack'
 
-export const WOLLOK_BASE_PACKAGE = 'wollok'
+export const WOLLOK_BASE_PACKAGE = 'wollok.'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import * as constants from './constants'
 import link from './linker'
 import { Environment } from './model'
 import { List } from './extensions'
@@ -19,6 +20,7 @@ function buildEnvironment(files: List<{ name: string, content: string }>, baseEn
   }), baseEnvironment)
 }
 
+export * from './constants'
 export * from './model'
 export * from './interpreter/runtimeModel'
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import * as constants from './constants'
 import link from './linker'
 import { Environment } from './model'
 import { List } from './extensions'

--- a/src/interpreter/runtimeModel.ts
+++ b/src/interpreter/runtimeModel.ts
@@ -155,7 +155,8 @@ export class Frame extends Context {
   }
 
   isCustom(): boolean {
-    return !this.node.sourceFileName?.startsWith(WOLLOK_BASE_PACKAGE) && !this.node.is(Environment) // TODO: create constant
+    const module = this.node.ancestors.find(ancestor => ancestor.is(Module)) as Module
+    return !module?.fullyQualifiedName?.startsWith(WOLLOK_BASE_PACKAGE) && !this.node.is(Environment)
   }
 }
 

--- a/src/interpreter/runtimeModel.ts
+++ b/src/interpreter/runtimeModel.ts
@@ -1,3 +1,4 @@
+import { WOLLOK_BASE_PACKAGE, WOLLOK_EXTRA_STACK_TRACE_HEADER } from '../constants'
 import { v4 as uuid } from 'uuid'
 import { getPotentiallyUninitializedLazy } from '../decorators'
 import { get, is, last, List, match, raise, when } from '../extensions'
@@ -50,7 +51,7 @@ export class WollokException extends Error {
   get message(): string {
     const error: RuntimeObject = this.instance
     error.assertIsException()
-    return `${error.innerValue ? error.innerValue.message : error.get('message')?.innerString ?? ''}\n${this.wollokStack}\n     Derived from TypeScript stack`
+    return `${error.innerValue ? error.innerValue.message : error.get('message')?.innerString ?? ''}\n${this.wollokStack}\n     ${WOLLOK_EXTRA_STACK_TRACE_HEADER}`
   }
 
   // TODO: Do we need to take this into consideration for Evaluation.copy()? This might be inside Exception objects
@@ -151,6 +152,10 @@ export class Frame extends Context {
 
   override toString(): string {
     return `${this.description}(${this.sourceInfo})`
+  }
+
+  isCustom(): boolean {
+    return !this.node.sourceFileName?.startsWith(WOLLOK_BASE_PACKAGE) && !this.node.is(Environment) // TODO: create constant
   }
 }
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -704,7 +704,7 @@ const usesReservedWords = (node: Class | Singleton | Variable | Field | Paramete
   const parent = node.ancestors.find(ancestor => ancestor.is(Package)) as Package | undefined
   const wordsReserved = LIBRARY_PACKAGES.flatMap(libPackage => node.environment.getNodeByFQN<Package>(libPackage).members.map(_ => _.name))
   wordsReserved.push('wollok')
-  return !!parent && !parent.fullyQualifiedName.includes(`${WOLLOK_BASE_PACKAGE}.`) && wordsReserved.includes(node.name)
+  return !!parent && !parent.fullyQualifiedName.includes(WOLLOK_BASE_PACKAGE) && wordsReserved.includes(node.name)
 }
 
 const supposedToReturnValue = (node: Node): boolean => match(node.parent)(

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -18,6 +18,7 @@
 // - Level could be different for the same Expectation on different nodes
 // - Problem could know how to convert to string, receiving the interpolation function (so it can be translated). This could let us avoid having parameters.
 // - Good default for simple problems, but with a config object for more complex, so we know what is each parameter
+import { WOLLOK_BASE_PACKAGE } from './constants'
 import { count, TypeDefinition, duplicates, is, isEmpty, last, List, match, notEmpty, when } from './extensions'
 // - Unified problem type
 import { Assignment, Body, Catch, Class, Code, Describe, Entity, Expression, Field, If, Import,
@@ -703,7 +704,7 @@ const usesReservedWords = (node: Class | Singleton | Variable | Field | Paramete
   const parent = node.ancestors.find(ancestor => ancestor.is(Package)) as Package | undefined
   const wordsReserved = LIBRARY_PACKAGES.flatMap(libPackage => node.environment.getNodeByFQN<Package>(libPackage).members.map(_ => _.name))
   wordsReserved.push('wollok')
-  return !!parent && !parent.fullyQualifiedName.includes('wollok.') && wordsReserved.includes(node.name)
+  return !!parent && !parent.fullyQualifiedName.includes(`${WOLLOK_BASE_PACKAGE}.`) && wordsReserved.includes(node.name)
 }
 
 const supposedToReturnValue = (node: Node): boolean => match(node.parent)(

--- a/src/wre/lang.ts
+++ b/src/wre/lang.ts
@@ -11,7 +11,8 @@ const lang: Natives = {
   Exception: {
     *initialize(self: RuntimeObject): Execution<void> {
       const stackTraceElements: RuntimeObject[] = []
-      for(const frame of this.frameStack.slice(0, -1)){
+      const customFrames = this.frameStack.slice(0, -1).filter(frame => frame.isCustom())
+      for(const frame of customFrames){
         const stackTraceElement = yield* this.send('createStackTraceElement', self, yield* this.reify(frame.description), yield* this.reify(frame.sourceInfo))
         stackTraceElements.unshift(stackTraceElement!)
       }


### PR DESCRIPTION
La idea es resolver [este issue](https://github.com/uqbar-project/wollok-ts-cli/issues/65) que está cargado para wollok-ts-cli.

Este PR viene de la mano de [este otro PR](https://github.com/uqbar-project/wollok-ts-cli/pull/95), donde acá

- filtro los frames asociados con el fully qualified name (`wollok.`) . Esto es algo que ya se hacía en Wollok Xtext y [que se implementó para wollok-cli que usa Java](https://github.com/uqbar-project/wollok/issues/1660).
- agregué de paso un archivo `constants.ts` donde la idea es poder seguir metiendo cosas ahí.

Me encantaría poder filtrar el stack trace de Typescript (es gracioso que en Wollok Xtext pasaba a veces con [el stack trace de Java](https://github.com/uqbar-project/wollok/issues/1375)), pero la verdad es que es muy raro como WollokException implementa un  `get message(): string` que arma todo el stack trace pero al final se le agrega el stack trace de TS de zopetón.

**Update**: hablando con NicoS, ahí entendí que WollokException hereda de Error, que es el objeto estándar de JS, que lamentablemente modela el `stack` como un string y no como una pila de mensajes evaluados como esperaría. Tratar de manipular eso es medio complicado dado que hay que interpretar el string por un lado y por otro hay que tratar de que se pueda seguir debuggeando la VM. Esta solución de compromiso para mí 
1. resuelve el problema (necesita de un ayudín de wollok-ts-cli)
2. y permite que se pueda seguir debuggeando errores falopa de la VM...