### PR TITLE
make shouldUseOverrideKeyword ignore initialize method

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
 export const WOLLOK_EXTRA_STACK_TRACE_HEADER = 'Derived from TypeScript stack'
 
 export const WOLLOK_BASE_PACKAGE = 'wollok.'
+
+export const INITIALIZE_METHOD_NAME = 'initialize'

--- a/src/interpreter/runtimeModel.ts
+++ b/src/interpreter/runtimeModel.ts
@@ -1,8 +1,8 @@
-import { WOLLOK_BASE_PACKAGE, WOLLOK_EXTRA_STACK_TRACE_HEADER } from '../constants'
 import { v4 as uuid } from 'uuid'
+import { INITIALIZE_METHOD_NAME, WOLLOK_BASE_PACKAGE, WOLLOK_EXTRA_STACK_TRACE_HEADER } from '../constants'
 import { getPotentiallyUninitializedLazy } from '../decorators'
 import { get, is, last, List, match, raise, when } from '../extensions'
-import { Assignment, Body, Catch, Describe, Environment, Entity, Expression, Id, If, Literal, LiteralValue, Method, Module, Name, New, Node, Package, Program, Reference, Return, Self, Send, Singleton, Super, Test, Throw, Try, Variable } from '../model'
+import { Assignment, Body, Catch, Describe, Entity, Environment, Expression, Id, If, Literal, LiteralValue, Method, Module, Name, New, Node, Package, Program, Reference, Return, Self, Send, Singleton, Super, Test, Throw, Try, Variable } from '../model'
 import { Interpreter } from './interpreter'
 
 const { isArray } = Array
@@ -675,7 +675,7 @@ export class Evaluation {
       instance.set(field.name, initialValue)
     }
 
-    yield * this.send('initialize', instance)
+    yield * this.send(INITIALIZE_METHOD_NAME, instance)
 
     if(!instance.module.name || instance.module.is(Describe))
       for (const field of instance.module.allFields)

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -184,7 +184,7 @@ export const shouldOnlyInheritFromMixin = error<Mixin>(node => node.supertypes.e
 }))
 
 export const shouldUseOverrideKeyword = warning<Method>(node =>
-  node.isOverride || !superclassMethod(node)
+  !(!node.isOverride && superclassMethod(node) && !['initialize'].includes(node.name))
 )
 
 export const possiblyReturningBlock = warning<Method>(node => {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -18,12 +18,14 @@
 // - Level could be different for the same Expectation on different nodes
 // - Problem could know how to convert to string, receiving the interpolation function (so it can be translated). This could let us avoid having parameters.
 // - Good default for simple problems, but with a config object for more complex, so we know what is each parameter
-import { WOLLOK_BASE_PACKAGE } from './constants'
-import { count, TypeDefinition, duplicates, is, isEmpty, last, List, match, notEmpty, when } from './extensions'
+import { INITIALIZE_METHOD_NAME, WOLLOK_BASE_PACKAGE } from './constants'
+import { count, duplicates, is, isEmpty, last, List, match, notEmpty, TypeDefinition, when } from './extensions'
 // - Unified problem type
-import { Assignment, Body, Catch, Class, Code, Describe, Entity, Expression, Field, If, Import,
+import {
+  Assignment, Body, Catch, Class, Code, Describe, Entity, Expression, Field, If, Import,
   Level, Literal, Method, Mixin, Module, NamedArgument, New, Node, Package, Parameter, ParameterizedType, Problem,
-  Program, Reference, Return, Self, Send, Sentence, Singleton, SourceIndex, SourceMap, Super, Test, Throw, Try, Variable } from './model'
+  Program, Reference, Return, Self, Send, Sentence, Singleton, SourceIndex, SourceMap, Super, Test, Throw, Try, Variable
+} from './model'
 
 const { entries } = Object
 
@@ -184,7 +186,7 @@ export const shouldOnlyInheritFromMixin = error<Mixin>(node => node.supertypes.e
 }))
 
 export const shouldUseOverrideKeyword = warning<Method>(node =>
-  !(!node.isOverride && superclassMethod(node) && !['initialize'].includes(node.name))
+  node.isOverride || !superclassMethod(node) || node.name == INITIALIZE_METHOD_NAME
 )
 
 export const possiblyReturningBlock = warning<Method>(node => {


### PR DESCRIPTION
Arregla #123 
Este PR modifica la validation ya existente `shouldUseOverrideKeyword` para que no aparezca si el metodo es initialize.

El programa que use para testearlo es ([PR en wollok-language](https://github.com/uqbar-project/wollok-language/pull/164)):

```wollok
// This describe should not trigger a shouldUseOverrideKeyword warning
// @Expect(code="shouldUseOverrideKeyword", level="warning")
describe "Fake describe" {
    method initialize() {

    }

    test "2 == 1 + 1" {
        assert.equals(2, 1+1)
    }
}


class Perro {
    // @Expect(code="shouldUseOverrideKeyword", level="warning")
    method initialize() {

    }

    method ladrar() {
        return "guau"
    }
}

```

Una pregunta que tengo es, hay algun `NotExpect`? ya que en este caso quiero testear que no aparece la validation.