### PR TITLE
Fix #170 unused variable

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -61,4 +61,5 @@ export const KEYWORDS = {
   FIXTURE: 'fixture',
   PROGRAM: 'program',
   PACKAGE: 'package',
+  ONLY: 'only',
 } as const

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -98,7 +98,4 @@ export const when = <T>(definition: TypeDefinition<T>) => <R>(handler: (m: T) =>
 export const anyPredicate = <Element>(...conditions: ((x: Element) => boolean)[]): (x: Element) => boolean => x =>
   conditions.some(condition => condition(x))
 
-export const hasWhitespace = (value: string): boolean => {
-  // console.info('   chequeo', `[${value}]`)
-  return !value || /\s/.test(value ?? '')
-}
+export const hasWhitespace = (value: string): boolean => !value || /\s/.test(value ?? '')

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -97,3 +97,8 @@ export const when = <T>(definition: TypeDefinition<T>) => <R>(handler: (m: T) =>
 
 export const anyPredicate = <Element>(...conditions: ((x: Element) => boolean)[]): (x: Element) => boolean => x =>
   conditions.some(condition => condition(x))
+
+export const hasWhitespace = (value: string): boolean => {
+  // console.info('   chequeo', `[${value}]`)
+  return !value || /\s/.test(value ?? '')
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,12 @@ import print from './printer/print'
 import WRE from './wre/wre.json'
 import WRENatives from './wre/wre.natives'
 
+export type FileContent = {
+  name: string,
+  content: string,
+}
 
-function buildEnvironment(files: List<{ name: string, content: string }>, baseEnvironment: Environment = fromJSON<Environment>(WRE)): Environment {
+function buildEnvironment(files: List<FileContent>, baseEnvironment: Environment = fromJSON<Environment>(WRE)): Environment {
 
   return link(files.map(({ name, content }) => {
     try {

--- a/src/model.ts
+++ b/src/model.ts
@@ -246,6 +246,7 @@ export class Body extends Node {
 
   override parent!: Program | Test | Method | If | Try | Catch
 
+  // TODO: is this ok? => this.parent.is(Method?)
   isEmpty(): boolean {
     return this.isSynthetic || this.parent.is(Method) || notEmpty(this.sentences)
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -127,9 +127,9 @@ const node = <N extends Node, P>(constructor: new (payload: P) => N) => (parser:
     endComment,
     index,
   )
-    .chain(payload => Parsimmon((input, index) => {
-      const [from, to] = sanitizeWhitespaces(payload[1], payload[4], input)
-      return makeSuccess<[Annotation[], Parsimmon.Index, P, Annotation | Annotation[], Parsimmon.Index]> (index, [payload[0], from, payload[2], payload[3], to])
+    .chain(([metadata, _start, payload, comment, _end]) => Parsimmon((input, index) => {
+      const [start, end] = sanitizeWhitespaces(_start, _end, input)
+      return makeSuccess<[Annotation[], Parsimmon.Index, P, Annotation | Annotation[], Parsimmon.Index]>(index, [metadata, start, payload, comment, end])
     }))
     .map(([metadata, start, payload, comment, end]) =>
       new constructor({ metadata: metadata.concat(comment), sourceMap: buildSourceMap(start, end), ...payload })

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,7 @@
 import Parsimmon, { Index, Parser, alt as alt_parser, any, index, lazy, makeSuccess, newline, notFollowedBy, of, regex, seq, seqObj, string, whitespace } from 'parsimmon'
 import unraw from 'unraw'
 import { ASSIGNATION_OPERATORS, INFIX_OPERATORS, PREFIX_OPERATORS } from './constants'
-import { List, discriminate, is, mapObject } from './extensions'
+import { List, discriminate, is, hasWhitespace, mapObject } from './extensions'
 import { Annotation, Assignment as AssignmentNode, BaseProblem, Body as BodyNode, Catch as CatchNode, Class as ClassNode, Closure as ClosureNode, Describe as DescribeNode, Entity as EntityNode, Expression as ExpressionNode, Field as FieldNode, If as IfNode, Import as ImportNode, Level, Literal as LiteralNode, LiteralValue, Method as MethodNode, Mixin as MixinNode, Name, NamedArgument as NamedArgumentNode, New as NewNode, Node, Package as PackageNode, Parameter as ParameterNode, ParameterizedType as ParameterizedTypeNode, Program as ProgramNode, Reference as ReferenceNode, Return as ReturnNode, Self as SelfNode, Send as SendNode, Sentence as SentenceNode, Singleton as SingletonNode, SourceIndex, SourceMap, Super as SuperNode, Test as TestNode, Throw as ThrowNode, Try as TryNode, Variable as VariableNode } from './model'
 
 // TODO: Use description in lazy() for better errors
@@ -90,6 +90,22 @@ const endComment =  alt(
   comment('end').sepBy(_) // after-line comments
 )
 
+export const sanitizeWhitespaces = (originalFrom: SourceIndex, originalTo: SourceIndex, input: any): SourceIndex[] => {
+  const hasWhitespacesBefore = hasWhitespace(input[originalTo.offset - 1])
+  if (!hasWhitespace(input.substring(originalFrom.offset, originalTo.offset)) || !hasWhitespacesBefore) return [originalFrom, originalTo]
+  const from = { ...originalFrom }
+  const adjustTo = hasWhitespacesBefore ? 1 : 0
+  const to = { ...originalTo, offset: originalTo.offset - adjustTo }
+  while(hasWhitespace(input[from.offset]) && from.offset < originalTo.offset) {
+    from.offset++
+  }
+  while(hasWhitespace(input[to.offset]) && to.offset > originalFrom.offset) {
+    to.offset--
+  }
+  to.offset = to.offset + adjustTo
+  return [from, to]
+}
+
 export const annotation: Parser<Annotation> = lazy(() =>
   string('@').then(obj({
     name,
@@ -110,9 +126,14 @@ const node = <N extends Node, P>(constructor: new (payload: P) => N) => (parser:
     lazy(parser),
     endComment,
     index,
-  ).map(([metadata, start, payload, comment, end]) =>
-    new constructor({ metadata: metadata.concat(comment), sourceMap: buildSourceMap(start, end), ...payload })
   )
+    .chain(payload => Parsimmon((input, index) => {
+      const [from, to] = sanitizeWhitespaces(payload[1], payload[4], input)
+      return makeSuccess<[Annotation[], Parsimmon.Index, P, Annotation | Annotation[], Parsimmon.Index]> (index, [payload[0], from, payload[2], payload[3], to])
+    }))
+    .map(([metadata, start, payload, comment, end]) =>
+      new constructor({ metadata: metadata.concat(comment), sourceMap: buildSourceMap(start, end), ...payload })
+    )
 
 export const File = (fileName: string): Parser<PackageNode> => lazy(() =>
   obj({

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -92,7 +92,8 @@ const endComment =  alt(
 
 export const sanitizeWhitespaces = (originalFrom: SourceIndex, originalTo: SourceIndex, input: any): SourceIndex[] => {
   const hasWhitespacesBefore = hasWhitespace(input[originalTo.offset - 1])
-  if (!hasWhitespace(input.substring(originalFrom.offset, originalTo.offset)) || !hasWhitespacesBefore) return [originalFrom, originalTo]
+  const firstCharacterWhitespace = hasWhitespace(input[originalFrom.offset])
+  if (!hasWhitespace(input.substring(originalFrom.offset, originalTo.offset)) || !hasWhitespacesBefore && !firstCharacterWhitespace) return [originalFrom, originalTo]
   const from = { ...originalFrom }
   const adjustTo = hasWhitespacesBefore ? 1 : 0
   const to = { ...originalTo, offset: originalTo.offset - adjustTo }
@@ -102,7 +103,7 @@ export const sanitizeWhitespaces = (originalFrom: SourceIndex, originalTo: Sourc
   while(hasWhitespace(input[to.offset]) && to.offset > originalFrom.offset) {
     to.offset--
   }
-  to.offset = to.offset + adjustTo
+  to.offset = to.offset + (hasWhitespace(input[to.offset]) ? 0 : 1)
   return [from, to]
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -91,12 +91,11 @@ const endComment =  alt(
 )
 
 export const sanitizeWhitespaces = (originalFrom: SourceIndex, originalTo: SourceIndex, input: any): SourceIndex[] => {
-  const hasWhitespacesBefore = hasWhitespace(input[originalTo.offset - 1])
-  const firstCharacterWhitespace = hasWhitespace(input[originalFrom.offset])
-  if (!hasWhitespace(input.substring(originalFrom.offset, originalTo.offset)) || !hasWhitespacesBefore && !firstCharacterWhitespace) return [originalFrom, originalTo]
+  const hasWhitespaceAtTheEnd = hasWhitespace(input[originalTo.offset - 1])
+  const shouldBeSanitized = hasWhitespace(input.substring(originalFrom.offset, originalTo.offset)) && hasWhitespaceAtTheEnd || hasWhitespace(input[originalFrom.offset])
+  if (!shouldBeSanitized) return [originalFrom, originalTo]
   const from = { ...originalFrom }
-  const adjustTo = hasWhitespacesBefore ? 1 : 0
-  const to = { ...originalTo, offset: originalTo.offset - adjustTo }
+  const to = { ...originalTo, offset: originalTo.offset - (hasWhitespaceAtTheEnd ? 1 : 0) }
   while(hasWhitespace(input[from.offset]) && from.offset < originalTo.offset) {
     from.offset++
   }

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -104,8 +104,6 @@ const sourceMapForNodeName = (node: Node & { name?: string }) => {
   return buildSourceMap(node, initialOffset, finalOffset)
 }
 
-const sourceMapForAssignmentVariable = (node: Assignment) => node.variable.sourceMap
-
 const sourceMapForOnlyTest = (node: Test) => buildSourceMap(node, 0, KEYWORDS.ONLY.length)
 
 const sourceMapForOverrideMethod = (node: Method) => buildSourceMap(node, 0, KEYWORDS.OVERRIDE.length)
@@ -181,7 +179,7 @@ export const shouldNotReassignConst = error<Assignment>(node => {
   const target = node?.variable?.target
   const referenceIsNotConstant = !target || (target.is(Variable) || target?.is(Field)) && !target.isConstant
   return referenceIsNotConstant && !target?.is(Parameter)
-}, undefined, sourceMapForAssignmentVariable)
+})
 
 // TODO: Test if the reference points to the right kind of node
 export const missingReference = error<Reference<Node>>(node => !!node.target)

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -512,7 +512,7 @@ export const shouldDefineConstInsteadOfVar = warning<Variable | Field>(node => {
     ),
     when(Module)(module => module.methods.some(method => assigns(method, node))),
   )
-})
+}, valuesForNodeName, sourceMapForNodeName)
 
 export const shouldNotUseVoidMethodAsValue = error<Send>(node => {
   if (!methodExists(node) || !supposedToReturnValue(node)) return true

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -87,7 +87,6 @@ const valuesForNodeName = (node: { name: string}) => [node.name ?? '']
 
 const sourceMapForNodeName = (node: Node & { name: string }) => {
   if (!node.sourceMap) return undefined
-  console.info('offset', node.kind, node.name, getOffsetForName(node))
   const nodeOffset = getOffsetForName(node)
   return node.sourceMap && new SourceMap({
     start: new SourceIndex({
@@ -124,9 +123,10 @@ export const nameShouldBeginWithUppercase = nameMatches(/^[A-Z]/)
 
 export const nameShouldBeginWithLowercase = nameMatches(/^[a-z_<]/)
 
-export const nameShouldNotBeKeyword = error<Entity | Parameter | Variable | Field | Method>(node =>
+export const nameShouldNotBeKeyword = error<Parameter | Variable | Field | Method>(node =>
   !RESERVED_WORDS.includes(node.name || ''),
-node => [node.name || ''],
+node => [node.name ?? ''],
+sourceMapForNodeName,
 )
 
 export const inlineSingletonShouldBeAnonymous = error<Singleton>(

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -83,9 +83,9 @@ const error = problem('error')
 // VALIDATION MESSAGES
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 
-const valuesForNodeName = (node: { name: string}) => [node.name ?? '']
+const valuesForNodeName = (node: { name?: string }) => [node.name ?? '']
 
-const sourceMapForNodeName = (node: Node & { name: string }) => {
+const sourceMapForNodeName = (node: Node & { name?: string }) => {
   if (!node.sourceMap) return undefined
   const nodeOffset = getOffsetForName(node)
   return node.sourceMap && new SourceMap({
@@ -125,7 +125,7 @@ export const nameShouldBeginWithLowercase = nameMatches(/^[a-z_<]/)
 
 export const nameShouldNotBeKeyword = error<Parameter | Variable | Field | Method>(node =>
   !RESERVED_WORDS.includes(node.name || ''),
-node => [node.name ?? ''],
+valuesForNodeName,
 sourceMapForNodeName,
 )
 
@@ -303,7 +303,9 @@ export const parameterShouldNotDuplicateExistingVariable = error<Parameter>(node
 export const shouldNotDuplicateLocalVariables = error<Variable>(node => !duplicatesLocalVariable(node), valuesForNodeName, sourceMapForNodeName)
 
 export const shouldNotDuplicateGlobalDefinitions = error<Module | Variable>(node =>
-  !node.name || !node.parent.is(Package) || isEmpty(node.siblings().filter(child => (child as Entity).name == node.name))
+  !node.name || !node.parent.is(Package) || isEmpty(node.siblings().filter(child => (child as Entity).name == node.name)),
+valuesForNodeName,
+sourceMapForNodeName,
 )
 
 export const shouldNotDuplicateVariablesInLinearization = error<Module>(node => {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -301,7 +301,7 @@ export const shouldMatchSuperclassReturnValue = error<Method>(node => {
   const lastSentence = last(node.sentences)
   const superclassSentence = last(overridenMethod.sentences)
   return !lastSentence || !superclassSentence || lastSentence.is(Return) === superclassSentence.is(Return) || lastSentence.is(Throw) || superclassSentence.is(Throw)
-})
+}, undefined, sourceMapForBody)
 
 export const shouldReturnAValueOnAllFlows = error<If>(node => {
   const lastThenSentence = last(node.thenBody.sentences)

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -477,7 +477,8 @@ sourceMapForNodeName)
 
 export const shouldNotDuplicatePackageName = error<Package>(node =>
   !node.siblings().some(sibling => sibling.is(Package) && sibling.name == node.name)
-)
+, valuesForNodeName,
+sourceMapForNodeName)
 
 export const shouldCatchUsingExceptionHierarchy = error<Catch>(node => {
   const EXCEPTION_CLASS = node.environment.getNodeByFQN<Class>('wollok.lang.Exception')

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -106,8 +106,9 @@ const sourceMapForNodeName = (node: Node & { name?: string }) => {
 
 const sourceMapForAssignmentVariable = (node: Assignment) => node.variable.sourceMap
 
-const sourceMapForOnlyTest = (node: Test) =>
-  buildSourceMap(node, 0, KEYWORDS.ONLY.length)
+const sourceMapForOnlyTest = (node: Test) => buildSourceMap(node, 0, KEYWORDS.ONLY.length)
+
+const sourceMapForOverrideMethod = (node: Method) => buildSourceMap(node, 0, KEYWORDS.OVERRIDE.length)
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 // VALIDATIONS
@@ -214,7 +215,8 @@ export const possiblyReturningBlock = warning<Method>(node => {
 
 export const shouldNotUseOverride = error<Method>(node =>
   node.parent.is(Mixin) || !node.isOverride || !!superclassMethod(node)
-)
+, valuesForNodeName,
+sourceMapForOverrideMethod)
 
 export const namedArgumentShouldExist = error<NamedArgument>(node => {
   const parent = getReferencedModule(node.parent)

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -366,7 +366,9 @@ export const shouldNotMarkMoreThanOneOnlyTest = warning<Test>(node =>
 export const shouldNotDefineNativeMethodsOnUnnamedSingleton = error<Method>(node => {
   const parent = node.parent
   return !node.isNative() || !parent.is(Singleton) || !!parent.name
-})
+},
+valuesForNodeName,
+sourceMapForNodeName)
 
 export const codeShouldBeReachable = error<If | Send>(node =>
   match(node)(

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -466,7 +466,8 @@ export const shouldInitializeConst = error<Variable>(node =>
     getContainer(node)?.is(Program) &&
     node.isConstant &&
     isInitialized(node))
-)
+, valuesForNodeName,
+sourceMapForNodeName)
 
 export const shouldNotDuplicatePackageName = error<Package>(node =>
   !node.siblings().some(sibling => sibling.is(Package) && sibling.name == node.name)

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -130,7 +130,9 @@ sourceMapForNodeName,
 )
 
 export const inlineSingletonShouldBeAnonymous = error<Singleton>(
-  singleton => singleton.parent.is(Package) || !singleton.name
+  singleton => singleton.parent.is(Package) || !singleton.name,
+  valuesForNodeName,
+  sourceMapForNodeName,
 )
 
 export const topLevelSingletonShouldHaveAName = error<Singleton>(

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -457,7 +457,8 @@ export const shouldNotUseReservedWords = warning<Class | Singleton | Variable | 
 
 export const shouldInitializeGlobalReference = error<Variable>(node =>
   !(node.isAtPackageLevel && isInitialized(node))
-)
+, valuesForNodeName,
+sourceMapForNodeName)
 
 export const shouldNotDefineUnusedVariables = warning<Field>(node => !unusedVariable(node), valuesForNodeName, sourceMapForNodeName)
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -211,14 +211,14 @@ export const shouldNotUseOverride = error<Method>(node =>
 export const namedArgumentShouldExist = error<NamedArgument>(node => {
   const parent = getReferencedModule(node.parent)
   return !parent || !!parent.lookupField(node.name)
-})
+}, valuesForNodeName, sourceMapForNodeName)
 
 export const namedArgumentShouldNotAppearMoreThanOnce = warning<NamedArgument>(node => {
   const nodeParent = node.parent
   let siblingArguments: List<NamedArgument> | undefined
   if (nodeParent.is(New)) siblingArguments = nodeParent.args
   return !siblingArguments || count(siblingArguments, _ => _.name === node.name) === 1
-})
+}, valuesForNodeName, sourceMapForNodeName)
 
 export const linearizationShouldNotRepeatNamedArguments = warning<Singleton | Class>(node => {
   const allNamedArguments = node.supertypes.flatMap(parent => parent.args.map(_ => _.name))
@@ -791,6 +791,7 @@ const getVariableOffset = (node: Variable | Field) => (node.isConstant ? KEYWORD
 
 const getOffsetForName = (node: Node): number => match(node)(
   when(Parameter)(() => 0),
+  when(NamedArgument)(() => 0),
   when(Variable)(node => getVariableOffset(node)),
   when(Field)(node => getVariableOffset(node) + (node.isProperty ? KEYWORDS.PROPERTY.length + 1 : 0)),
   when(Entity)(node => node.is(Singleton) ? KEYWORDS.WKO.length + 1 : node.kind.length + 1),

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -110,9 +110,12 @@ const sourceMapForOverrideMethod = (node: Method) => buildSourceMap(node, 0, KEY
 
 const sourceMapForConditionInIf = (node: If) => node.condition.sourceMap
 
+const sourceMapForSentence = (sentence: Sentence) =>
+  sentence.is(Return) ? sentence.value?.sourceMap : sentence.sourceMap
+
 const sourceMapForSentences = (sentences: List<Sentence>) => new SourceMap({
-  start: sentences[0]!.sourceMap!.start,
-  end: last(sentences)!.sourceMap!.end,
+  start: sourceMapForSentence(sentences[0])!.start,
+  end: sourceMapForSentence(last(sentences)!)!.end,
 })
 
 const sourceMapForReturnValue = (node: Method) => {
@@ -195,7 +198,7 @@ export const shouldNotOnlyCallToSuper = warning<Method>(node => {
   return isEmpty(node.sentences) || !node.sentences.every(sentence =>
     callsSuperWithSameArgs(sentence) || sentence.is(Return) && callsSuperWithSameArgs(sentence.value)
   )
-})
+}, undefined, sourceMapForBody)
 
 export const shouldNotInstantiateAbstractClass = error<New>(node => !node.instantiated.target?.isAbstract)
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -237,7 +237,7 @@ export const shouldInitializeInheritedAttributes = error<Singleton>(
 
 export const shouldInitializeSingletonAttribute = error<Field>(node => {
   return !node.parent.is(Singleton) || !isUninitialized(node.value)
-})
+}, valuesForNodeName, sourceMapForNodeName)
 
 export const shouldNotUseSelf = error<Self>(node => {
   const ancestors = node.ancestors

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -104,6 +104,8 @@ const sourceMapForNodeName = (node: Node & { name?: string }) => {
   return buildSourceMap(node, initialOffset, finalOffset)
 }
 
+const sourceMapForAssignmentVariable = (node: Assignment) => node.variable.sourceMap
+
 const sourceMapForOnlyTest = (node: Test) =>
   buildSourceMap(node, 0, KEYWORDS.ONLY.length)
 
@@ -176,7 +178,7 @@ export const shouldNotReassignConst = error<Assignment>(node => {
   const target = node?.variable?.target
   const referenceIsNotConstant = !target || (target.is(Variable) || target?.is(Field)) && !target.isConstant
   return referenceIsNotConstant && !target?.is(Parameter)
-})
+}, undefined, sourceMapForAssignmentVariable)
 
 // TODO: Test if the reference points to the right kind of node
 export const missingReference = error<Reference<Node>>(node => !!node.target)
@@ -813,6 +815,7 @@ const getOffsetForName = (node: Node): number => match(node)(
   when(Variable)(node => getVariableOffset(node)),
   when(Field)(node => getVariableOffset(node) + (node.isProperty ? KEYWORDS.PROPERTY.length + 1 : 0)),
   when(Method)(node => (node.isOverride ? KEYWORDS.OVERRIDE.length + 1 : 0) + node.kind.length + 1),
+  when(Reference)(node => node.name.length + 1),
   when(Entity)(node => node.is(Singleton) ? KEYWORDS.WKO.length + 1 : node.kind.length + 1),
 )
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -469,7 +469,10 @@ export const getterMethodShouldReturnAValue = warning<Method>(node =>
   !isGetter(node) || node.isSynthetic || node.isNative() || node.isAbstract() || node.sentences.some(_ => _.is(Return))
 )
 
-export const shouldNotUseReservedWords = warning<Class | Singleton | Variable | Field | Parameter>(node => !usesReservedWords(node))
+export const shouldNotUseReservedWords = warning<Class | Singleton | Variable | Field | Parameter>(node =>
+  !usesReservedWords(node)
+, valuesForNodeName,
+sourceMapForNodeName)
 
 export const shouldInitializeGlobalReference = error<Variable>(node =>
   !(node.isAtPackageLevel && isInitialized(node))

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -496,7 +496,8 @@ export const catchShouldBeReachable = error<Catch>(node => {
 
 export const shouldNotDuplicateEntities = error<Entity | Variable>(node =>
   !node.name || !node.parent.is(Package) || node.parent.imports.every(importFile => !entityIsAlreadyUsedInImport(importFile.entity.target, node.name!))
-)
+, valuesForNodeName,
+sourceMapForNodeName)
 
 export const shouldNotImportSameFile = error<Import>(node =>
   ['wtest', 'wpgm'].some(allowedExtension => node.parent.fileName?.endsWith(allowedExtension)) || node.entity.target !== node.parent

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -110,6 +110,8 @@ const sourceMapForOnlyTest = (node: Test) => buildSourceMap(node, 0, KEYWORDS.ON
 
 const sourceMapForOverrideMethod = (node: Method) => buildSourceMap(node, 0, KEYWORDS.OVERRIDE.length)
 
+const sourceMapForConditionInIf = (node: If) => node.condition.sourceMap
+
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 // VALIDATIONS
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
@@ -348,7 +350,8 @@ export const shouldNotCompareEqualityOfSingleton = warning<Send>(node => {
 
 export const shouldUseBooleanValueInIfCondition = error<If>(node =>
   isBooleanOrUnknownType(node.condition)
-)
+, undefined,
+sourceMapForConditionInIf)
 
 export const shouldUseBooleanValueInLogicOperation = error<Send>(node => {
   if (!isBooleanMessage(node)) return true

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -118,12 +118,12 @@ const sourceMapForSentences = (sentences: List<Sentence>) => new SourceMap({
   end: sourceMapForSentence(last(sentences)!)!.end,
 })
 
-const sourceMapForReturnValue = (node: Method) => {
-  if (!node.body || node.body === KEYWORDS.NATIVE || isEmpty(node.body.sentences)) return node.sourceMap
-  const lastSentence = last(node.body.sentences)!
-  if (!lastSentence.is(Return)) return node.sourceMap
-  return lastSentence.value!.sourceMap
-}
+// const sourceMapForReturnValue = (node: Method) => {
+//   if (!node.body || node.body === KEYWORDS.NATIVE || isEmpty(node.body.sentences)) return node.sourceMap
+//   const lastSentence = last(node.body.sentences)!
+//   if (!lastSentence.is(Return)) return lastSentence.sourceMap
+//   return lastSentence.value!.sourceMap
+// }
 
 const sourceMapForBody = (node: Method | Test) => {
   if (!node.body || node.body === KEYWORDS.NATIVE || isEmpty(node.body.sentences)) return node.sourceMap
@@ -243,7 +243,8 @@ export const possiblyReturningBlock = warning<Method>(node => {
   if (node.sentences.length !== 1) return true
   const singleSentence = node.sentences[0]
   return !(singleSentence.isSynthetic && singleSentence.is(Return) && singleSentence.value?.is(Singleton) && singleSentence.value.isClosure(0))
-}, undefined, sourceMapForReturnValue)
+})
+//, undefined, sourceMapForReturnValue)
 
 export const shouldNotUseOverride = error<Method>(node =>
   node.parent.is(Mixin) || !node.isOverride || !!superclassMethod(node)

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -122,7 +122,7 @@ const sourceMapForReturnValue = (node: Method) => {
   return lastSentence.value!.sourceMap
 }
 
-const sourceMapForBody = (node: Method) => {
+const sourceMapForBody = (node: Method | Test) => {
   if (!node.body || node.body === KEYWORDS.NATIVE || isEmpty(node.body.sentences)) return node.sourceMap
   return sourceMapForSentences(node.body.sentences)
 }
@@ -477,10 +477,10 @@ export const shouldUseConditionalExpression = warning<If>(node => {
   )
 })
 
-
 export const shouldHaveAssertInTest = warning<Test>(node =>
   !node.body.isEmpty() || sendsMessageToAssert(node.body)
-)
+, undefined,
+sourceMapForBody)
 
 export const shouldMatchFileExtension = error<Test | Program>(node => {
   const filename = node.sourceFileName

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -537,7 +537,7 @@ export const shouldHaveDifferentName = error<Test>(node => {
     when(Node)(_ => []),
   )
   return !tests || tests.every(other => node === other || other.name !== node.name)
-})
+}, valuesForNodeName, sourceMapForNodeName)
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 // HELPER FUNCTIONS

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -300,7 +300,7 @@ export const parameterShouldNotDuplicateExistingVariable = error<Parameter>(node
   return parameterNotDuplicated && !hasDuplicatedVariable(nodeMethod.parent, node.name)
 })
 
-export const shouldNotDuplicateLocalVariables = error<Variable>(node => !duplicatesLocalVariable(node))
+export const shouldNotDuplicateLocalVariables = error<Variable>(node => !duplicatesLocalVariable(node), valuesForNodeName, sourceMapForNodeName)
 
 export const shouldNotDuplicateGlobalDefinitions = error<Module | Variable>(node =>
   !node.name || !node.parent.is(Package) || isEmpty(node.siblings().filter(child => (child as Entity).name == node.name))

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -293,7 +293,8 @@ export const shouldReturnAValueOnAllFlows = error<If>(node => {
 
 export const shouldNotDuplicateFields = error<Field>(node =>
   count(node.parent.allFields, _ => _.name == node.name) === 1
-)
+, valuesForNodeName,
+sourceMapForNodeName)
 
 export const parameterShouldNotDuplicateExistingVariable = error<Parameter>(node => {
   const nodeMethod = getVariableContainer(node)

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -360,7 +360,8 @@ export const shouldUseBooleanValueInLogicOperation = error<Send>(node => {
 
 export const shouldNotDefineUnnecesaryIf = error<If>(node =>
   notEmpty(node.elseBody.sentences) || !node.condition.is(Literal) || node.condition.value !== true
-)
+, undefined,
+sourceMapForConditionInIf)
 
 export const shouldNotDefineEmptyDescribe = warning<Describe>(node =>
   notEmpty(node.tests)

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -412,7 +412,8 @@ export const shouldNotDefineUnnecessaryCondition = warning<If | Send>(node =>
 
 export const overridingMethodShouldHaveABody = error<Method>(node =>
   !node.isOverride || node.isNative() || node.isConcrete()
-)
+, valuesForNodeName,
+sourceMapForNodeName)
 
 export const shouldUseConditionalExpression = warning<If>(node => {
   const thenValue = isEmpty(node.thenBody.sentences) ? undefined : valueFor(last(node.thenBody.sentences))
@@ -794,8 +795,8 @@ const getOffsetForName = (node: Node): number => match(node)(
   when(NamedArgument)(() => 0),
   when(Variable)(node => getVariableOffset(node)),
   when(Field)(node => getVariableOffset(node) + (node.isProperty ? KEYWORDS.PROPERTY.length + 1 : 0)),
+  when(Method)(node => (node.isOverride ? KEYWORDS.OVERRIDE.length + 1 : 0) + node.kind.length + 1),
   when(Entity)(node => node.is(Singleton) ? KEYWORDS.WKO.length + 1 : node.kind.length + 1),
-  when(Method)(node => node.kind.length + 1),
 )
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -354,7 +354,8 @@ export const shouldNotDefineEmptyDescribe = warning<Describe>(node =>
 
 export const shouldHaveNonEmptyName = warning<Describe | Test>(node =>
   (node.name ?? '').replaceAll('"', '').trim() !== ''
-)
+, valuesForNodeName,
+sourceMapForNodeName)
 
 export const shouldNotMarkMoreThanOneOnlyTest = warning<Test>(node =>
   !node.isOnly || count(node.siblings(), element => element.is(Test) && element.isOnly) <= 1

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -326,7 +326,9 @@ export const shouldHaveBody = error<Method>(node => {
 
 export const shouldNotDefineGlobalMutableVariables = error<Variable>(variable => {
   return variable.isConstant || !variable.isAtPackageLevel
-})
+},
+valuesForNodeName,
+sourceMapForNodeName)
 
 export const shouldNotCompareEqualityOfSingleton = warning<Send>(node => {
   const arg: Expression = node.args[0]

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,5 +1,5 @@
 import { should, use } from 'chai'
-import { Annotation, Assignment, Body, Catch, Class, Closure, Describe, Field, If, Import, Literal, Method, Mixin, NamedArgument, New, Package, Parameter, ParameterizedType, Program, Reference, Return, Send, Singleton, Super, Test, Throw, Try, Variable } from '../src/model'
+import { Annotation, Assignment, Body, Catch, Class, Closure, Describe, Field, If, Import, Literal, Method, Mixin, NamedArgument, New, Package, Parameter, ParameterizedType, Program, Reference, Return, Send, Singleton, SourceIndex, Super, Test, Throw, Try, Variable } from '../src/model'
 import * as parse from '../src/parser'
 import { parserAssertions } from './assertions'
 
@@ -268,7 +268,7 @@ describe('Wollok parser', () => {
             members: [new Class({ name: 'C' })],
           })
         ).and.be.tracedTo(0, 24)
-          .and.have.nested.property('members.0').tracedTo(12, 23)
+          .and.have.nested.property('members.0').tracedTo(12, 22)
       })
 
       it('should parse non-empty packages with more than one class', () => {
@@ -281,8 +281,8 @@ describe('Wollok parser', () => {
             ],
           })
         ).and.be.tracedTo(0, 35)
-          .and.have.nested.property('members.0').tracedTo(12, 23)
-          .and.also.have.nested.property('members.1').tracedTo(23, 34)
+          .and.have.nested.property('members.0').tracedTo(12, 22)
+          .and.also.have.nested.property('members.1').tracedTo(23, 33)
 
       })
 
@@ -396,7 +396,7 @@ describe('Wollok parser', () => {
           })
         ).and.be.tracedTo(0, 30)
           .and.have.nested.property('members.0').tracedTo(10, 15)
-          .and.also.have.nested.property('members.1').tracedTo(16, 29)
+          .and.also.have.nested.property('members.1').tracedTo(16, 28)
       })
 
       it('should parse classes that inherit from other class', () => {
@@ -418,7 +418,7 @@ describe('Wollok parser', () => {
             ],
           })
         ).and.be.tracedTo(0, 28)
-          .and.have.nested.property('supertypes.0').tracedTo(17, 26)
+          .and.have.nested.property('supertypes.0').tracedTo(17, 25)
           .and.also.have.nested.property('supertypes.0.reference').tracedTo(17, 18)
       })
 
@@ -624,7 +624,7 @@ describe('Wollok parser', () => {
             ],
           })
         ).and.be.tracedTo(0, 28)
-          .and.have.nested.property('supertypes.0').tracedTo(17, 26)
+          .and.have.nested.property('supertypes.0').tracedTo(17, 25)
           .and.also.have.nested.property('supertypes.0.reference').tracedTo(17, 18)
       })
 
@@ -639,7 +639,7 @@ describe('Wollok parser', () => {
           })
         ).and.be.tracedTo(0, 30)
           .and.have.nested.property('members.0').tracedTo(10, 15)
-          .and.also.have.nested.property('members.1').tracedTo(16, 29)
+          .and.also.have.nested.property('members.1').tracedTo(16, 28)
       })
 
       it('should parse annotated nodes', () => {
@@ -765,7 +765,7 @@ describe('Wollok parser', () => {
           })
         ).and.be.tracedTo(0, 32)
           .and.have.nested.property('members.0').tracedTo(12, 17)
-          .and.also.have.nested.property('members.1').tracedTo(18, 31)
+          .and.also.have.nested.property('members.1').tracedTo(18, 30)
       })
 
       it('should parse objects that inherits from a class', () => {
@@ -792,7 +792,7 @@ describe('Wollok parser', () => {
             })],
           })
         ).and.be.tracedTo(0, 36)
-          .and.have.nested.property('supertypes.0').tracedTo(18, 34)
+          .and.have.nested.property('supertypes.0').tracedTo(18, 33)
           .and.also.have.nested.property('supertypes.0.reference').tracedTo(18, 19)
           .and.also.have.nested.property('supertypes.0.args.0').tracedTo(20, 25)
           .and.also.have.nested.property('supertypes.0.args.0.value').tracedTo(24, 25)
@@ -1148,8 +1148,8 @@ describe('Wollok parser', () => {
             ],
           })
         ).and.be.tracedTo(0, 47)
-          .and.have.nested.property('members.0').tracedTo(18, 32)
-          .and.also.have.nested.property('members.1').tracedTo(32, 46)
+          .and.have.nested.property('members.0').tracedTo(18, 31)
+          .and.also.have.nested.property('members.1').tracedTo(32, 45)
       })
 
       it('should parse describes with fields', () => {
@@ -1163,7 +1163,7 @@ describe('Wollok parser', () => {
         'describe "name" { method m(){} }'.should.be.parsedBy(parser).into(
           new Describe({ name: '"name"', members: [new Method({ name: 'm', body: new Body() })] })
         ).and.be.tracedTo(0, 32)
-          .and.have.nested.property('members.0').tracedTo(18, 31)
+          .and.have.nested.property('members.0').tracedTo(18, 30)
       })
 
       it('should parse annotated nodes', () => {
@@ -2509,7 +2509,7 @@ describe('Wollok parser', () => {
             })
           ).and.be.tracedTo(0, 17)
             .and.have.nested.property('condition').tracedTo(3, 4)
-            .and.also.have.nested.property('thenBody').tracedTo(5, 9)
+            .and.also.have.nested.property('thenBody').tracedTo(5, 8)
             .and.also.have.nested.property('thenBody.sentences.0').tracedTo(6, 7)
             .and.also.have.nested.property('elseBody').tracedTo(14, 17)
             .and.also.have.nested.property('elseBody.sentences.0').tracedTo(15, 16)
@@ -3058,7 +3058,7 @@ describe('Wollok parser', () => {
             }),
           ).and.be.tracedTo(0, 29)
             .and.have.nested.property('members.0').tracedTo(9, 14)
-            .and.also.have.nested.property('members.1').tracedTo(15, 28)
+            .and.also.have.nested.property('members.1').tracedTo(15, 27)
         })
 
         it('should parse literal objects that inherit from a class', () => {
@@ -3097,7 +3097,7 @@ describe('Wollok parser', () => {
               ],
             }),
           ).and.be.tracedTo(0, 27)
-            .and.have.nested.property('supertypes.0').tracedTo(16, 25)
+            .and.have.nested.property('supertypes.0').tracedTo(16, 24)
             .and.also.have.nested.property('supertypes.0.reference').tracedTo(16, 17)
             .and.also.have.nested.property('supertypes.0.args.0').tracedTo(18, 23)
         })
@@ -3545,6 +3545,54 @@ describe('Wollok parser', () => {
 
       })
 
+    })
+
+  })
+
+  describe('sanitizeWhitespaces', () => {
+
+    const input = `
+class Bird {
+  var property energy = 100
+  var times = 0
+
+  method fly() {
+    energy = energy - 50
+    times = times + 1
+  }
+
+  method eat(grams) {
+    energy = energy + 10 * grams
+  }
+
+  method energy() = energy
+
+}
+
+class OtherClass {
+
+}
+`
+    const textFor = ([from, to]: SourceIndex[], input: string): string => input.substring(from.offset, to.offset)
+
+    it('should return same input if there are no whitespaces', () => {
+      const result = parse.sanitizeWhitespaces(new SourceIndex({ line: 2, column: 1, offset: 1 }), new SourceIndex({ line: 2, column: 6, offset: 6 }), input)
+      textFor(result, input).should.be.equal('class')
+    })
+
+    it('should trim trailing whitespaces', () => {
+      const result = parse.sanitizeWhitespaces(new SourceIndex({ line: 2, column: 1, offset: 1 }), new SourceIndex({ line: 2, column: 7, offset: 7 }), input)
+      textFor(result, input).should.be.equal('class')
+    })
+
+    it('should trim beginning whitespaces for the input', () => {
+      const result = parse.sanitizeWhitespaces(new SourceIndex({ line: 4, column: 16, offset: 57 }), new SourceIndex({ line: 6, column: 15, offset: 73 }), input)
+      textFor(result, input).should.be.equal('method fly()')
+    })
+
+    it('should trim beginning & trailing whitespaces for the input', () => {
+      const result = parse.sanitizeWhitespaces(new SourceIndex({ line: 4, column: 16, offset: 57 }), new SourceIndex({ line: 6, column: 16, offset: 74 }), input)
+      textFor(result, input).should.be.equal('method fly()')
     })
 
   })

--- a/test/typeSystemInference.test.ts
+++ b/test/typeSystemInference.test.ts
@@ -13,7 +13,7 @@ should()
 describe('Wollok Type System Inference', () => {
 
 
-  buildEnvironmentForEachFile(TESTS_PATH, (filePackage) => {
+  buildEnvironmentForEachFile(TESTS_PATH, (filePackage, fileContent) => {
     const { environment } = filePackage
     if (!getPotentiallyUninitializedLazy(environment, 'typeRegistry')) { // Just run type inference once
       const logger = undefined
@@ -38,7 +38,7 @@ describe('Wollok Type System Inference', () => {
             if (type !== nodeType) fail(`Expected ${type} but got ${nodeType} for ${node}`)
 
           } else { // Assert problem
-            const expectedProblem = validateExpectationProblem(expectation, problems, node)
+            const expectedProblem = validateExpectationProblem(expectation, problems, node, fileContent)
             problems.splice(problems.indexOf(expectedProblem), 1)
           }
         }

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -10,7 +10,7 @@ should()
 
 describe('Wollok Validations', () => {
 
-  buildEnvironmentForEachFile(TESTS_PATH, (filePackage) => {
+  buildEnvironmentForEachFile(TESTS_PATH, (filePackage, fileContent) => {
 
     it(filePackage.name, () => {
       const allProblems = validate(filePackage)
@@ -21,7 +21,7 @@ describe('Wollok Validations', () => {
         const expectedProblems = expectations.get(node) || []
 
         for (const expectedProblem of expectedProblems) {
-          validateExpectationProblem(expectedProblem, problems, node)
+          validateExpectationProblem(expectedProblem, problems, node, fileContent)
         }
 
         for (const problem of problems) {


### PR DESCRIPTION
@PalumboN : Acá yo hice una solución (marco solo el nombre, como en Xtext, me gusta más):

![image](https://github.com/uqbar-project/wollok-ts/assets/4549002/1563d892-be40-4231-bc6a-ef933feb7265)

pero más allá de que hay que revisar las otras validaciones a ver qué onda (fijate que la otra validación quedó igual) a mí me gustaría tener algo como

```wollok
class SomeClass {
  @Expect(code="shouldNotDefineUnusedVariables", level="warning", expectedOn="unusedVariable")
  var unusedVariable = 0
```

La macana es que estamos un poco lejos de ésto, porque en el nodo no tenemos nada del texto, solo el archivo, con lo cual para poder hacer el cálculo en base al sourceMap del nodo tenés que hacer un laburo medio paja. La alternativa a eso podría ser

```wollok
class SomeClass {
  @Expect(code="shouldNotDefineUnusedVariables", level="warning", range="7:20")
  var unusedVariable = 0
```

que es más lograble, hay que buscar para la línea del annotated node cuál es el valor. Incluso podría definirse el range como "7" y que el resto sea hasta el final del sourceIndex del annotated node.

