### PR TITLE
Fix ignore wollok code in Type System

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wollok-ts",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wollok-ts",
-      "version": "4.0.7",
+      "version": "4.0.8",
       "license": "MIT",
       "dependencies": {
         "@types/parsimmon": "^1.10.8",

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,3 +1,4 @@
+import { WOLLOK_BASE_PACKAGE } from './constants'
 import { cached, getPotentiallyUninitializedLazy, lazy } from './decorators'
 import { ConstructorFor, InstanceOf, is, last, List, mapObject, Mixable, MixinDefinition, MIXINS, notEmpty, TypeDefinition } from './extensions'
 import { TypeRegistry, WollokType } from './typeSystem/wollokTypes'
@@ -280,6 +281,10 @@ export function Entity<S extends Mixable<Node>>(supertype: S) {
       return parent?.is(Package) || parent?.is(Describe)
         ? `${parent.fullyQualifiedName}.${label}`
         : label
+    }
+
+    get isBaseWollokCode(): boolean {
+      return this.fullyQualifiedName.includes(WOLLOK_BASE_PACKAGE)
     }
   }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -284,7 +284,7 @@ export function Entity<S extends Mixable<Node>>(supertype: S) {
     }
 
     get isBaseWollokCode(): boolean {
-      return this.fullyQualifiedName.includes(WOLLOK_BASE_PACKAGE)
+      return this.fullyQualifiedName.startsWith(WOLLOK_BASE_PACKAGE)
     }
   }
 

--- a/src/typeSystem/typeVariables.ts
+++ b/src/typeSystem/typeVariables.ts
@@ -1,3 +1,4 @@
+import { WOLLOK_BASE_PACKAGE } from '../constants'
 import { is, last, List, match, when } from '../extensions'
 import { Assignment, Body, Class, Closure, Describe, Environment, Expression, Field, If, Import, Literal, Method, Module, NamedArgument, New, Node, Package, Parameter, Program, Reference, Return, Self, Send, Singleton, Super, Test, Throw, Try, Variable } from '../model'
 import { ANY, AtomicType, ELEMENT, RETURN, TypeSystemProblem, VOID, WollokAtomicType, WollokClosureType, WollokMethodType, WollokModuleType, WollokParameterType, WollokParametricType, WollokType, WollokUnionType } from './wollokTypes'
@@ -92,7 +93,7 @@ const inferEnvironment = (env: Environment) => {
 }
 
 const inferPackage = (p: Package) => {
-  if (p.name.startsWith('wollok')) return //TODO: Fix wrong inferences
+  if (p.isBaseWollokCode) return // Wollok code should be typed by annotations
   p.children.forEach(createTypeVariables)
 }
 


### PR DESCRIPTION
El Type System estaba ignorando las carpetas que comenzaban con `wollok` 😓 

Ahí lo cambié y agregué un método en el Node más peola.

### Test: https://github.com/uqbar-project/wollok-language/pull/170