### PR TITLE
Formatter for prefix operators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wollok-ts",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wollok-ts",
-      "version": "4.0.7",
+      "version": "4.0.8",
       "license": "MIT",
       "dependencies": {
         "@types/parsimmon": "^1.10.8",

--- a/src/model.ts
+++ b/src/model.ts
@@ -739,6 +739,10 @@ export class Send extends Expression(Node) {
   get kind(): 'Send' { return 'Send' }
   readonly receiver!: Expression
   readonly message!: Name
+  /**
+   * @description Used for prefix operators, represents the original
+   * operator name before it was transformed to a message
+   */
   readonly originalOperator?: Name
   readonly args!: List<Expression>
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,5 +1,6 @@
+import { INFIX_OPERATORS, PREFIX_OPERATORS } from './constants'
 import { cached, getPotentiallyUninitializedLazy, lazy } from './decorators'
-import { ConstructorFor, InstanceOf, is, last, List, mapObject, Mixable, MixinDefinition, MIXINS, notEmpty, TypeDefinition } from './extensions'
+import { ConstructorFor, InstanceOf, is, last, List, mapObject, Mixable, MixinDefinition, MIXINS, isEmpty, notEmpty, TypeDefinition } from './extensions'
 import { TypeRegistry, WollokType } from './typeSystem/wollokTypes'
 
 const { isArray } = Array
@@ -738,6 +739,7 @@ export class Send extends Expression(Node) {
   get kind(): 'Send' { return 'Send' }
   readonly receiver!: Expression
   readonly message!: Name
+  readonly originalOperator?: Name
   readonly args!: List<Expression>
 
   constructor({ args = [], ...payload }: Payload<Send, 'receiver' | 'message'>) {
@@ -746,6 +748,17 @@ export class Send extends Expression(Node) {
 
   get signature(): string {
     return `${this.message}/${this.args.length}`
+  }
+
+  isPrefixOperator(): boolean {
+    return this.originalOperator != undefined
+      && Object.keys(PREFIX_OPERATORS).includes(this.originalOperator)
+      && isEmpty(this.args)
+  }
+
+  isInfixOperator(): boolean {
+    return INFIX_OPERATORS.flat().includes(this.message)
+      && this.args.length === 1
   }
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -396,9 +396,9 @@ const infixMessageChain = (precedenceLevel = 0): Parser<ExpressionNode> => {
 const prefixMessageChain: Parser<ExpressionNode> = lazy(() =>
   alt(
     node(SendNode)(() => obj({
-      message: operator(keys(PREFIX_OPERATORS)).map(_ => PREFIX_OPERATORS[_]),
+      message: operator(keys(PREFIX_OPERATORS)),
       receiver: prefixMessageChain,
-    })),
+    }).map((send) => ({ ...send, message: PREFIX_OPERATORS[send.message], originalOperator: send.message }))),
     postfixMessageChain
   )
 )

--- a/src/printer/utils.ts
+++ b/src/printer/utils.ts
@@ -1,10 +1,6 @@
 import { IDoc, append, braces, brackets, choice, dquotes, enclose, intersperse, lineBreak, softLine } from 'prettier-printer'
-import { INFIX_OPERATORS } from '../constants'
 
 export type DocTransformer = (doc: IDoc) => IDoc
-
-export const infixOperators = INFIX_OPERATORS.flat()
-
 
 type Encloser = [IDoc, IDoc]
 export const listEnclosers: Encloser = brackets

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -2075,7 +2075,7 @@ describe('Wollok parser', () => {
 
         it('should parse the negation of a reference with the "!" operator', () => {
           '!a'.should.be.parsedBy(parser).into(
-            new Send({ receiver: new Reference({ name: 'a' }), message: 'negate' })
+            new Send({ receiver: new Reference({ name: 'a' }), message: 'negate', originalOperator: '!' })
           ).and.be.tracedTo(0, 2)
             .and.have.nested.property('receiver').tracedTo(1, 2)
         })
@@ -2087,10 +2087,13 @@ describe('Wollok parser', () => {
                 receiver: new Send({
                   receiver: new Reference({ name: 'a' }),
                   message: 'negate',
+                  originalOperator: '!',
                 }),
                 message: 'negate',
+                originalOperator: '!',
               }),
               message: 'negate',
+              originalOperator: '!',
             })
           ).and.be.tracedTo(0, 4)
             .and.have.nested.property('receiver').tracedTo(1, 4)
@@ -2099,7 +2102,7 @@ describe('Wollok parser', () => {
         })
 
         it('should parse arithmetic operators in prefix operations', () => {
-          '-1'.should.be.parsedBy(parser).into(new Send({ receiver: new Literal({ value: 1 }), message: 'invert' }))
+          '-1'.should.be.parsedBy(parser).into(new Send({ receiver: new Literal({ value: 1 }), message: 'invert', originalOperator: '-' }))
             .and.be.tracedTo(0, 2)
             .and.have.nested.property('receiver').tracedTo(1, 2)
         })
@@ -2110,8 +2113,10 @@ describe('Wollok parser', () => {
               receiver: new Send({
                 receiver: new Reference({ name: 'a' }),
                 message: 'negate',
+                originalOperator: '!',
               }),
               message: 'negate',
+              originalOperator: '!',
               metadata: [new Annotation('A', { x: 1 })],
             })
           )
@@ -2123,9 +2128,11 @@ describe('Wollok parser', () => {
               receiver: new Send({
                 receiver: new Reference({ name: 'a' }),
                 message: 'negate',
+                originalOperator: '!',
                 metadata: [new Annotation('A', { x: 1 })],
               }),
               message: 'negate',
+              originalOperator: '!',
             })
           )
 
@@ -2134,8 +2141,10 @@ describe('Wollok parser', () => {
               receiver: new Send({
                 receiver: new Reference({ name: 'a', metadata: [new Annotation('A', { x: 1 })] }),
                 message: 'negate',
+                originalOperator: '!',
               }),
               message: 'negate',
+              originalOperator: '!',
             })
           )
         })

--- a/test/printer.test.ts
+++ b/test/printer.test.ts
@@ -52,6 +52,17 @@ describe('Wollok Printer', () => {
           }
         `)
       })
+      it('Prefix operator', () => {
+        `object pepita {
+          method prueba() {
+            return not(!false && false.negate()) && (-1 < +2)
+          }
+        }`.should.be.formattedTo(`
+          object pepita {
+            method prueba() = (not ((!false) && false.negate())) && ((-1) < (+2))
+          }
+        `)
+      })
     })
 
     describe('If', () => {


### PR DESCRIPTION
Soluciona item de #190 

Para poder mostrar el operador correcto (e.g. `not`, `!` o `negate`) lo guarda en el `Send` al parsear.