### PR TITLE
Fix imports with same name

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "buildWRE": "ts-node scripts/buildWRE.ts",
     "prepare": "ts-node scripts/fetchLanguage.ts && npm run buildWRE",
     "diagnostic": "tsc --noEmit --diagnostics --extendedDiagnostics",
-    "test": "npm run test:lint && npm run test:unit && npm run test:sanity && npm run test:examples && npm run test:validations && npm run test:typeSystem",
+    "test": "npm run test:lint && npm run test:unit && npm run test:sanity && npm run test:examples && npm run test:validations && npm run test:typeSystem && npm run test:printer",
     "test:lint": "eslint .",
     "test:coverage": "nyc --reporter=lcov npm run test",
     "test:unit": "mocha --parallel -r ts-node/register/transpile-only test/**/*.test.ts",

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from 'uuid'
 import { divideOn, is, List } from './extensions'
-import { BaseProblem, Entity, Environment, Field, Id, Level, Module, Name, Node, Package, Parameter, ParameterizedType, Reference, Scope, SourceMap } from './model'
+import { BaseProblem, Entity, Environment, Field, Id, Import, Level, Module, Name, Node, Package, Parameter, ParameterizedType, Reference, Scope, SourceMap } from './model'
 const { assign } = Object
 
 
@@ -99,13 +99,13 @@ const assignScopes = (environment: Environment) => {
   environment.forEach((node, parent) => {
     assign(node, {
       scope: new LocalScope(
-        node.is(Reference) && parent!.is(ParameterizedType)
+        node.is(Import) || (node.is(Reference) && parent!.is(ParameterizedType))
           ? parent?.parent.scope
           : parent?.scope
       ),
     })
 
-    if (node.is(Entity)) parent?.scope?.register(...scopeContribution(node))
+    parent?.scope?.register(...scopeContribution(node))
   })
 
   environment.forEach((node, parent) => {
@@ -130,9 +130,6 @@ const assignScopes = (environment: Environment) => {
     if (node.is(Module)) {
       node.scope.include(...node.hierarchy.slice(1).map(supertype => supertype.scope))
     }
-
-    if (parent && !node.is(Entity))
-      parent!.scope.register(...scopeContribution(node))
   })
 }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -713,6 +713,7 @@ export class Reference<N extends Node> extends Expression(Node) {
 
   constructor(payload: Payload<Reference<N>, 'name'>) { super(payload) }
 
+  @cached
   get target(): N | undefined { return this.scope.resolve(this.name) }
 }
 

--- a/test/linker.test.ts
+++ b/test/linker.test.ts
@@ -615,6 +615,34 @@ describe('Wollok linker', () => {
       D.supertypes[0].reference.should.target(T)
     })
 
+    it('should not mix imported references with same name at different level', () => {
+      const environment = link([
+        new Package({
+          name: 'p',
+          imports: [
+            new Import({ entity: new Reference({ name: 'q' }), isGeneric: true }),
+          ],
+          members: [
+            new Singleton({ name: 'o', supertypes: [new ParameterizedType({ reference: new Reference({ name: 'q' }) })] }),
+          ],
+        }),
+        new Package({
+          name: 'q',
+          members: [
+            new Singleton({ name: 'q' }),
+          ],
+        }),
+      ], WRE)
+
+      const p = environment.getNodeByFQN<Package>('p')
+      const o = environment.getNodeByFQN<Singleton>('p.o')
+      const packageQ = environment.getNodeByFQN<Package>('q')
+      const objQ = environment.getNodeByFQN<Singleton>('q.q')
+
+      p.imports[0].entity.should.target(packageQ)
+      o.supertypes[0].reference.should.target(objQ)
+    })
+
     it('qualified references should not consider parent scopes for non-root steps', () => {
       const environment = link([
         new Package({


### PR DESCRIPTION
Este PR arregla parte de los problemas al tener entities con el mismo nombre que packages (por ejemplo `object pepita` en `pepita.wlk`).

Al hacer el import, la nueva definición del objeto pisaba la del archivo referenciado por el import.

Ahora el import agrega las definiciones al package (como antes) pero tiene como parent el abuelo (el padre del package), de esa forma el scope del import no se ve afectado por su propio linkeo.

También puse un `@cache` en el método `target()`, ya que todas las referencias de los scopes son estáticas... no sé si afectará (para bien) la performance.