### PR TITLE
Fix #167 -> Getter method should return a value

### DIFF
--- a/src/validator.ts
+++ b/src/validator.ts
@@ -502,7 +502,7 @@ export const shouldImplementAllMethodsInHierarchy = error<Class | Singleton>(nod
 })
 
 export const getterMethodShouldReturnAValue = warning<Method>(node =>
-  !isGetter(node) || node.isSynthetic || node.isNative() || node.isAbstract() || node.sentences.some(_ => _.is(Return))
+  !isGetter(node) || node.isSynthetic || node.isNative() || node.isAbstract() || node.sentences.some(returnsAValue)
 , undefined,
 sourceMapForBody)
 


### PR DESCRIPTION
Se corrige #167 agregando el test reportado en el issue en [otro PR](https://github.com/uqbar-project/wollok-language/pull/173) de Language. Para eso aprovechamos una definición que considera casos que se estaban escapando en el validador actual.
