### PR TITLE
Fix #195 Recursive Assignment

### DIFF
--- a/src/interpreter/runtimeModel.ts
+++ b/src/interpreter/runtimeModel.ts
@@ -2,9 +2,9 @@ import { v4 as uuid } from 'uuid'
 import { INITIALIZE_METHOD_NAME, LIST_MODULE, SET_MODULE, WOLLOK_BASE_PACKAGE, WOLLOK_EXTRA_STACK_TRACE_HEADER } from '../constants'
 import { getPotentiallyUninitializedLazy } from '../decorators'
 import { get, is, last, List, match, raise, when } from '../extensions'
-import { Assignment, Body, Catch, Class, Describe, Entity, Environment, Expression, Id, If, Literal, LiteralValue, Method, Module, Name, New, Node, Package, Program, Reference, Return, Self, Send, Singleton, Super, Test, Throw, Try, Variable } from '../model'
+import { Assignment, Body, Catch, Class, Describe, Entity, Environment, Expression, Field, Id, If, Literal, LiteralValue, Method, Module, Name, New, Node, Package, Program, Reference, Return, Self, Send, Singleton, Super, Test, Throw, Try, Variable } from '../model'
 import { Interpreter } from './interpreter'
-import { getUninitializedAttributesForInstantiation } from '../validator'
+import { getUninitializedAttributesForInstantiation, loopInAssignment } from '../validator'
 
 const { isArray } = Array
 const { keys, entries } = Object
@@ -450,6 +450,9 @@ export class Evaluation {
     if(!node.scope) return this.currentFrame.get(node.name) ?? raise(new Error(`Could not resolve unlinked reference to ${node.name} or its a reference to void`))
 
     const target = node.target
+    if (target?.is(Field) && loopInAssignment(target.value, target.name)) {
+      raise(new Error(`Error initializing field ${target.name}: stack overflow`))
+    }
 
     return this.currentFrame.get(
       target?.is(Module) || target?.is(Variable) && getPotentiallyUninitializedLazy(target, 'parent')?.is(Package)

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -591,6 +591,8 @@ export const shouldNotUseVoidMethodAsValue = error<Send>(node => {
   return !method || method.isNative() || method.isAbstract() || returnsValue(method)
 })
 
+export const shouldNotAssignValueInLoop = error<Field>(node => !loopInAssignment(node.value, node.name))
+
 export const shouldHaveDifferentName = error<Test>(node => {
   const tests: List<Test> = match(node.parent)(
     when(Describe)(describe => describe.tests),
@@ -853,6 +855,9 @@ const isInitialized = (node: Variable) =>
   node.value.is(Literal) &&
   node.value.isNull()
 
+export const loopInAssignment = (node: Expression, variableName: string) =>
+  node.is(Send) && methodExists(node) && node.receiver.is(Self) && node.message === variableName
+
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 // REPORT HELPERS
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
@@ -885,7 +890,7 @@ const validationsByKind = (node: Node): Record<string, Validation<any>> => match
   when(Class)(() => ({ nameShouldBeginWithUppercase, nameShouldNotBeKeyword, shouldNotHaveLoopInHierarchy, linearizationShouldNotRepeatNamedArguments, shouldNotDefineMoreThanOneSuperclass, superclassShouldBeLastInLinearization, shouldNotDuplicateGlobalDefinitions, shouldNotDuplicateVariablesInLinearization, shouldImplementAllMethodsInHierarchy, shouldNotUseReservedWords, shouldNotDuplicateEntities })),
   when(Singleton)(() => ({ nameShouldBeginWithLowercase, inlineSingletonShouldBeAnonymous, topLevelSingletonShouldHaveAName, nameShouldNotBeKeyword, shouldInitializeInheritedAttributes, linearizationShouldNotRepeatNamedArguments, shouldNotDefineMoreThanOneSuperclass, superclassShouldBeLastInLinearization, shouldNotDuplicateGlobalDefinitions, shouldNotDuplicateVariablesInLinearization, shouldImplementInheritedAbstractMethods, shouldImplementAllMethodsInHierarchy, shouldNotUseReservedWords, shouldNotDuplicateEntities })),
   when(Mixin)(() => ({ nameShouldBeginWithUppercase, shouldNotHaveLoopInHierarchy, shouldOnlyInheritFromMixin, shouldNotDuplicateGlobalDefinitions, shouldNotDuplicateVariablesInLinearization, shouldNotDuplicateEntities })),
-  when(Field)(() => ({ nameShouldBeginWithLowercase, shouldNotAssignToItselfInDeclaration, nameShouldNotBeKeyword, shouldNotDuplicateFields, shouldNotUseReservedWords, shouldNotDefineUnusedVariables, shouldDefineConstInsteadOfVar, shouldInitializeSingletonAttribute })),
+  when(Field)(() => ({ nameShouldBeginWithLowercase, shouldNotAssignToItselfInDeclaration, nameShouldNotBeKeyword, shouldNotDuplicateFields, shouldNotUseReservedWords, shouldNotDefineUnusedVariables, shouldDefineConstInsteadOfVar, shouldInitializeSingletonAttribute, shouldNotAssignValueInLoop })),
   when(Method)(() => ({ onlyLastParameterCanBeVarArg, nameShouldNotBeKeyword, methodShouldHaveDifferentSignature, shouldNotOnlyCallToSuper, shouldUseOverrideKeyword, possiblyReturningBlock, shouldNotUseOverride, shouldMatchSuperclassReturnValue, shouldNotDefineNativeMethodsOnUnnamedSingleton, overridingMethodShouldHaveABody, getterMethodShouldReturnAValue, shouldHaveBody })),
   when(Variable)(() => ({ nameShouldBeginWithLowercase, nameShouldNotBeKeyword, shouldNotAssignToItselfInDeclaration, shouldNotDuplicateLocalVariables, shouldNotDuplicateGlobalDefinitions, shouldNotDefineGlobalMutableVariables, shouldNotUseReservedWords, shouldInitializeGlobalReference, shouldDefineConstInsteadOfVar, shouldNotDuplicateEntities, shouldInitializeConst })),
   when(Assignment)(() => ({ shouldNotAssignToItself, shouldNotReassignConst })),


### PR DESCRIPTION
Agrega por un lado un validador para que salte una asignación a un Field que entra en loop infinito:

![image](https://github.com/uqbar-project/wollok-ts/assets/4549002/bdf75578-5886-400c-89eb-1199825230fe)

Y al intérprete se le agrega esa validación para que tire un error más representativo:

![image](https://github.com/uqbar-project/wollok-ts/assets/4549002/dd5cdb40-3d29-4d10-a36b-d969be6d4058)

Viene acompañado de 2 PRs:

- [LSP IDE](https://github.com/uqbar-project/wollok-lsp-ide/pull/142) para incorporar mensaje de error
- [Language](https://github.com/uqbar-project/wollok-language/pull/174) para incorporar un sanity test
