### PR TITLE
Fix #198 - empty if

### DIFF
--- a/src/typeSystem/typeVariables.ts
+++ b/src/typeSystem/typeVariables.ts
@@ -197,8 +197,10 @@ const inferIf = (_if: If) => {
     typeVariableFor(_if)
       .beSupertypeOf(typeVariableFor(last(_if.elseBody.sentences)!))
   }
-  return typeVariableFor(_if) // TODO: only for if-expression
-    .beSupertypeOf(typeVariableFor(last(_if.thenBody.sentences)!))
+  if (_if.thenBody.sentences.length) {
+    return typeVariableFor(_if) // TODO: only for if-expression
+      .beSupertypeOf(typeVariableFor(last(_if.thenBody.sentences)!))
+  }
 }
 
 const inferReference = (r: Reference<Node>) => {


### PR DESCRIPTION
Cuando el if está vacío en la sentencia then, el type system rompía y eso impedía validar el documento. Ahora sí se puede generar el warning:

![image](https://github.com/uqbar-project/wollok-ts/assets/4549002/4ea58ccf-d764-47d6-a551-e9f20d0fa42b)

Relacionado con 

- [un PR de language](https://github.com/uqbar-project/wollok-language/pull/175) que agrega el test de regresión
- [un PR de LSP-IDE](https://github.com/uqbar-project/wollok-lsp-ide/pull/143) que corrige otro manejo de nulls para hover y mejora el logger
