### PR TITLE
Fix #193 Unused variable actually used in block

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export const WOLLOK_EXTRA_STACK_TRACE_HEADER = 'Derived from TypeScript stack'
 export const WOLLOK_BASE_PACKAGE = 'wollok.'
 
 export const INITIALIZE_METHOD_NAME = 'initialize'
+export const CLOSURE_METHOD_NAME = '<apply>'
 
 export const PREFIX_OPERATORS: Record<Name, Name> = {
   '!': 'negate',

--- a/src/interpreter/runtimeModel.ts
+++ b/src/interpreter/runtimeModel.ts
@@ -1,5 +1,5 @@
 import { v4 as uuid } from 'uuid'
-import { INITIALIZE_METHOD_NAME, LIST_MODULE, SET_MODULE, WOLLOK_BASE_PACKAGE, WOLLOK_EXTRA_STACK_TRACE_HEADER } from '../constants'
+import { CLOSURE_METHOD_NAME, INITIALIZE_METHOD_NAME, LIST_MODULE, SET_MODULE, WOLLOK_BASE_PACKAGE, WOLLOK_EXTRA_STACK_TRACE_HEADER } from '../constants'
 import { getPotentiallyUninitializedLazy } from '../decorators'
 import { get, is, last, List, match, raise, when } from '../extensions'
 import { Assignment, Body, Catch, Class, Describe, Entity, Environment, Expression, Id, If, Literal, LiteralValue, Method, Module, Name, New, Node, Package, Program, Reference, Return, Self, Send, Singleton, Super, Test, Throw, Try, Variable } from '../model'
@@ -141,7 +141,7 @@ export class Frame extends Context {
   // TODO: On error report, this tells the node line, but not the actual error line.
   //        For example, an error on a test would say the test start line, not the line where the error occurred.
   get sourceInfo(): string {
-    const target = this.node.is(Method) && this.node.name === '<apply>'
+    const target = this.node.is(Method) && this.node.name === CLOSURE_METHOD_NAME
       ? this.node.parent
       : this.node
     return target.sourceInfo

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,4 @@
-import { INFIX_OPERATORS, PREFIX_OPERATORS, WOLLOK_BASE_PACKAGE } from './constants'
+import { CLOSURE_METHOD_NAME, INFIX_OPERATORS, PREFIX_OPERATORS, WOLLOK_BASE_PACKAGE } from './constants'
 import { cached, getPotentiallyUninitializedLazy, lazy } from './decorators'
 import { ConstructorFor, InstanceOf, is, last, List, mapObject, Mixable, MixinDefinition, MIXINS, isEmpty, notEmpty, TypeDefinition } from './extensions'
 import { TypeRegistry, WollokType } from './typeSystem/wollokTypes'
@@ -551,8 +551,8 @@ export class Singleton extends Expression(Module(Node)) {
   @cached
   isClosure(arity?: number): boolean {
     return arity === undefined
-      ? this.methods.some(_ => _.name === '<apply>')
-      : !!this.lookupMethod('<apply>', arity)
+      ? this.methods.some(_ => _.name === CLOSURE_METHOD_NAME)
+      : !!this.lookupMethod(CLOSURE_METHOD_NAME, arity)
   }
 }
 
@@ -862,7 +862,7 @@ export const Closure = ({ sentences, parameters, code, ...payload }: ClosurePayl
   return new Singleton({
     supertypes: [new ParameterizedType({ reference: new Reference({ name: 'wollok.lang.Closure' }) })],
     members: [
-      new Method({ name: '<apply>', parameters, body: new Body({ sentences: [...initialSentences, ...lastSentence] }) }),
+      new Method({ name: CLOSURE_METHOD_NAME, parameters, body: new Body({ sentences: [...initialSentences, ...lastSentence] }) }),
       ...code ? [
         new Field({ name: '<toString>', isConstant: true, value: new Literal({ value: code }) }),
       ] : [],

--- a/src/typeSystem/constraintBasedTypeSystem.ts
+++ b/src/typeSystem/constraintBasedTypeSystem.ts
@@ -1,3 +1,4 @@
+import { CLOSURE_METHOD_NAME } from '../constants'
 import { anyPredicate, is, isEmpty, notEmpty } from '../extensions'
 import { Environment, Module, Node, Reference } from '../model'
 import { newTypeVariables, TypeVariable, typeVariableFor } from './typeVariables'
@@ -80,7 +81,7 @@ export const bindReceivedMessages = (tVar: TypeVariable): boolean => {
   let changed = false
   for (const type of types) {
     for (const send of tVar.messages) {
-      const message = send.message == 'apply' ? '<apply>' : send.message // 'apply' is a special case for closures
+      const message = send.message == 'apply' ? CLOSURE_METHOD_NAME : send.message // 'apply' is a special case for closures
       const method = type.lookupMethod(message, send.args.length, { allowAbstractMethods: true })
       if (!method)
         return reportProblem(tVar, new TypeSystemProblem('methodNotFound', [send.signature, type.name]))

--- a/src/typeSystem/typeVariables.ts
+++ b/src/typeSystem/typeVariables.ts
@@ -1,3 +1,4 @@
+import { CLOSURE_METHOD_NAME } from '../constants'
 import { is, last, List, match, when } from '../extensions'
 import { Assignment, Body, Class, Closure, Describe, Environment, Expression, Field, If, Import, Literal, Method, Module, NamedArgument, New, Node, Package, Parameter, Program, Reference, Return, Self, Send, Singleton, Super, Test, Throw, Try, Variable } from '../model'
 import { ANY, AtomicType, ELEMENT, RETURN, TypeSystemProblem, VOID, WollokAtomicType, WollokClosureType, WollokMethodType, WollokModuleType, WollokParameterType, WollokParametricType, WollokType, WollokUnionType } from './wollokTypes'
@@ -31,7 +32,7 @@ function newTVarFor(node: Node) {
     newTVar.setType(new WollokMethodType(annotatedVar, parameters, annotatedVariableMap(node)), false)
   }
   if (node.is(Singleton) && node.isClosure()) {
-    const methodApply = node.methods.find(_ => _.name === '<apply>')!
+    const methodApply = node.methods.find(_ => _.name === CLOSURE_METHOD_NAME)!
     const parameters = methodApply.parameters.map(typeVariableFor)
     // annotatedVar = newSynteticTVar() // But for methods, annotations reference to return tVar
     const returnType = typeVariableFor(methodApply).atParam(RETURN)

--- a/src/wre/lang.ts
+++ b/src/wre/lang.ts
@@ -1,3 +1,4 @@
+import { CLOSURE_METHOD_NAME } from '../constants'
 import { hash, isEmpty, List } from '../extensions'
 import { Evaluation, Execution, Frame, Natives, RuntimeObject, RuntimeValue } from '../interpreter/runtimeModel'
 import { Class, Node, Singleton } from '../model'
@@ -702,7 +703,7 @@ const lang: Natives = {
     *apply(this: Evaluation, self: RuntimeObject, args: RuntimeObject): Execution<RuntimeValue> {
       args.assertIsCollection()
 
-      const method = self.module.lookupMethod('<apply>', args.innerCollection.length)
+      const method = self.module.lookupMethod(CLOSURE_METHOD_NAME, args.innerCollection.length)
       if (!method) return yield* this.send('messageNotUnderstood', self, yield* this.reify('apply'), args)
 
       const locals = yield* this.localsFor(method, args.innerCollection)


### PR DESCRIPTION
![image](https://github.com/uqbar-project/wollok-ts/assets/4549002/65faad48-1f88-4ef4-b6ee-dc955181325e)

Ya no se reporta la variable como sin ser usada.

De paso `<apply>` queda como constante...

Relacionado hay un [PR de language](https://github.com/uqbar-project/wollok-language/pull/176)