### PR TITLE
Moving functions from lsp-ide into wollok-ts

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -317,3 +317,17 @@ export const workspacePackage = (environment: Environment): Package => environme
 
 export const targettingAt = <T extends Node>(aNode: T) => (anotherNode: Node): anotherNode is Reference<T>  =>
   anotherNode.is(Reference) && anotherNode.target === aNode
+
+export const projectPackages = (environment: Environment): Package[] =>
+  environment.members.slice(1)
+
+export const isImportedIn = (importedPackage: Package, importingPackage: Package): boolean =>
+  importedPackage !== importingPackage &&
+  !importingPackage.imports.some(imported => imported.entity.target === importedPackage) &&
+  !importedPackage.isGlobalPackage
+
+export const mayExecute = (method: Method) => (node: Node): boolean =>
+  node.is(Send) &&
+  node.message === method.name &&
+  // exclude cases where a message is sent to a different singleton
+  !(node.receiver.is(Reference) && node.receiver.target?.is(Singleton) && node.receiver.target !== method.parent)

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import { parentModule } from './helpers';
+import { parentModule } from './helpers'
 import { BOOLEAN_MODULE, CLOSURE_EVALUATE_METHOD, CLOSURE_TO_STRING_METHOD, INITIALIZE_METHOD, KEYWORDS, NUMBER_MODULE, OBJECT_MODULE, STRING_MODULE, WOLLOK_BASE_PACKAGE } from './constants'
 import { List, count, is, isEmpty, last, match, notEmpty, when } from './extensions'
 import { Assignment, Body, Class, Describe, Entity, Environment, Expression, Field, If, Import, Literal, LiteralValue, Method, Module, NamedArgument, New, Node, Package, Parameter, ParameterizedType, Program, Reference, Return, Self, Send, Sentence, Singleton, Super, Test, Throw, Try, Variable } from './model'

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,4 @@
+import { parentModule } from './helpers';
 import { BOOLEAN_MODULE, CLOSURE_EVALUATE_METHOD, CLOSURE_TO_STRING_METHOD, INITIALIZE_METHOD, KEYWORDS, NUMBER_MODULE, OBJECT_MODULE, STRING_MODULE, WOLLOK_BASE_PACKAGE } from './constants'
 import { List, count, is, isEmpty, last, match, notEmpty, when } from './extensions'
 import { Assignment, Body, Class, Describe, Entity, Environment, Expression, Field, If, Import, Literal, LiteralValue, Method, Module, NamedArgument, New, Node, Package, Parameter, ParameterizedType, Program, Reference, Return, Self, Send, Sentence, Singleton, Super, Test, Throw, Try, Variable } from './model'
@@ -321,10 +322,18 @@ export const targettingAt = <T extends Node>(aNode: T) => (anotherNode: Node): a
 export const projectPackages = (environment: Environment): Package[] =>
   environment.members.slice(1)
 
-export const isImportedIn = (importedPackage: Package, importingPackage: Package): boolean =>
-  importedPackage !== importingPackage &&
-  !importingPackage.imports.some(imported => imported.entity.target === importedPackage) &&
+export const isNotImportedIn = (importedPackage: Package, importingPackage: Package): boolean => {
+  console.info(importedPackage !== importingPackage, !importingPackage.imports.some(imported => imported.entity.target === importedPackage), !importedPackage.isGlobalPackage)
+  return importedPackage !== importingPackage &&
+  !importingPackage.imports.some(imported => imported.entity.target && belongsTo(imported.entity.target, importedPackage)) &&
   !importedPackage.isGlobalPackage
+}
+
+export const belongsTo = (node: Node, mainPackage: Package): boolean =>
+  match(node)(
+    when(Package)((pkg) => pkg === mainPackage),
+    when(Node)((node) => node.parent === mainPackage),
+  )
 
 export const mayExecute = (method: Method) => (node: Node): boolean =>
   node.is(Send) &&

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,3 @@
-import { parentModule } from './helpers'
 import { BOOLEAN_MODULE, CLOSURE_EVALUATE_METHOD, CLOSURE_TO_STRING_METHOD, INITIALIZE_METHOD, KEYWORDS, NUMBER_MODULE, OBJECT_MODULE, STRING_MODULE, WOLLOK_BASE_PACKAGE } from './constants'
 import { List, count, is, isEmpty, last, match, notEmpty, when } from './extensions'
 import { Assignment, Body, Class, Describe, Entity, Environment, Expression, Field, If, Import, Literal, LiteralValue, Method, Module, NamedArgument, New, Node, Package, Parameter, ParameterizedType, Program, Reference, Return, Self, Send, Sentence, Singleton, Super, Test, Throw, Try, Variable } from './model'

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -322,12 +322,10 @@ export const targettingAt = <T extends Node>(aNode: T) => (anotherNode: Node): a
 export const projectPackages = (environment: Environment): Package[] =>
   environment.members.slice(1)
 
-export const isNotImportedIn = (importedPackage: Package, importingPackage: Package): boolean => {
-  console.info(importedPackage !== importingPackage, !importingPackage.imports.some(imported => imported.entity.target === importedPackage), !importedPackage.isGlobalPackage)
-  return importedPackage !== importingPackage &&
+export const isNotImportedIn = (importedPackage: Package, importingPackage: Package): boolean =>
+  importedPackage !== importingPackage &&
   !importingPackage.imports.some(imported => imported.entity.target && belongsTo(imported.entity.target, importedPackage)) &&
   !importedPackage.isGlobalPackage
-}
 
 export const belongsTo = (node: Node, mainPackage: Package): boolean =>
   match(node)(

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,6 +1,6 @@
 import { should, use } from 'chai'
 import sinonChai from 'sinon-chai'
-import { BOOLEAN_MODULE, Body, Class, Evaluation, Interpreter, LIST_MODULE, Literal, Method, NUMBER_MODULE, OBJECT_MODULE, Package, Reference, STRING_MODULE, Singleton, WRENatives, allAvailableMethods, implicitImport, link, literalValueToClass, parentModule } from '../src'
+import { BOOLEAN_MODULE, Body, Class, Evaluation, Interpreter, LIST_MODULE, Literal, Method, NUMBER_MODULE, OBJECT_MODULE, Package, Reference, STRING_MODULE, Singleton, WRENatives, allAvailableMethods, implicitImport, link, literalValueToClass, parentModule, projectPackages } from '../src'
 import { WREEnvironment, environmentWithEntities } from './utils'
 
 use(sinonChai)
@@ -124,6 +124,15 @@ describe('Wollok helpers', () => {
       implicitImport(customClass).should.be.false
     })
 
+  })
+
+  describe('project packages', () => {
+
+    it('should return the right package from an environment', () => {
+      const environment = basicEnvironmentWithSingleClass()
+      const mainPackage = environment.getNodeByFQN('aves')
+      projectPackages(environment).should.deep.equal([mainPackage])
+    })
   })
 
 })

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,6 +1,6 @@
 import { should, use } from 'chai'
 import sinonChai from 'sinon-chai'
-import { BOOLEAN_MODULE, Body, Class, Environment, Evaluation, Import, Interpreter, LIST_MODULE, Literal, Method, NUMBER_MODULE, OBJECT_MODULE, Package, Reference, STRING_MODULE, Send, Singleton, WRENatives, allAvailableMethods, implicitImport, isNotImportedIn, link, linkSentenceInNode, literalValueToClass, mayExecute, parentModule, parse, projectPackages } from '../src'
+import { BOOLEAN_MODULE, Body, Class, Environment, Evaluation, Import, Interpreter, LIST_MODULE, Literal, Method, NUMBER_MODULE, OBJECT_MODULE, Package, Reference, STRING_MODULE, Singleton, WRENatives, allAvailableMethods, implicitImport, isNotImportedIn, link, linkSentenceInNode, literalValueToClass, mayExecute, parentModule, parse, projectPackages } from '../src'
 import { WREEnvironment, environmentWithEntities } from './utils'
 
 use(sinonChai)

--- a/test/interpreter.test.ts
+++ b/test/interpreter.test.ts
@@ -63,7 +63,7 @@ describe('Wollok Interpreter', () => {
       const sentence = new Send({ receiver: new Reference({ name: 'p.o' }), message: 'm' })
       const interpreter = new Interpreter(Evaluation.build(environment, {}))
 
-        interpreter.exec(sentence)!.innerNumber!.should.equal(5)
+      interpreter.exec(sentence)!.innerNumber!.should.equal(5)
     })
 
     it('should fail when executing a missing unlinked reference', () => {


### PR DESCRIPTION
Como parte de la épica de mejoras de UX para LSP-IDE aparecieron varias funciones que están en el archivo wollok.ts y otras en references, mi idea es que desaparezcan y que directamente usemos las definiciones de acá.

[Issue original](https://github.com/uqbar-project/wollok-lsp-ide/issues/147)

Además agregué tests unitarios
