### PR TITLE
Fix #124 unused variable actually used in describe method

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -212,8 +212,8 @@ export const unusedVariable = (node: Field): boolean => {
   const allFields = parent.allFields
   const allMethods = parent.is(Describe) ? (parent.methods as List<Test | Method>).concat(parent.tests) : parent.allMethods
   return !node.isProperty && node.name != CLOSURE_TO_STRING_METHOD
-    && allMethods.every(method => !methodOrTestUsesField(method, node))
-    && allFields.every(field => !usesField(field.value, node))
+    && allMethods.every((method: Method | Test) => !methodOrTestUsesField(method, node))
+    && allFields.every((field: Field) => !usesField(field.value, node))
 }
 
 export const usesReservedWords = (node: Class | Singleton | Variable | Field | Parameter): boolean => {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -207,10 +207,13 @@ export const assignsVariable = (sentence: Sentence | Body, variable: Variable | 
   when(Expression)(_ => false),
 )
 
+export const callables = (node: Describe): (Method | Test)[] =>
+  node.members.filter(member => member.is(Test) || member.is(Method)) as (Test | Method)[]
+
 export const unusedVariable = (node: Field): boolean => {
   const parent = node.parent
   const allFields = parent.allFields
-  const allMethods = parent.is(Describe) ? (parent.methods as List<Test | Method>).concat(parent.tests) : parent.allMethods
+  const allMethods = parent.is(Describe) ? callables(parent) : [...parent.allMethods]
   return !node.isProperty && node.name != CLOSURE_TO_STRING_METHOD
     && allMethods.every((method: Method | Test) => !methodOrTestUsesField(method, node))
     && allFields.every((field: Field) => !usesField(field.value, node))

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -148,11 +148,8 @@ export const isGetter = (node: Method): boolean => node.parent.allFields.map(_ =
 
 export const methodOrTestUsesField = (parent: Method | Test, field: Field): boolean => parent.sentences.some(sentence => usesField(sentence, field))
 
-export const usesField = (node: Sentence | Body | NamedArgument | Field, field: Field): boolean => {
-  if (node.sourceFileName === 'shouldNotDefineUnusedVariables2.wtest' && node.kind === 'Field') {
-    console.info(node.kind, node.name, node.value)
-  }
-  return match(node)(
+export const usesField = (node: Sentence | Body | NamedArgument | Field, field: Field): boolean =>
+  match(node)(
     when(Singleton)(node => {
       if (!node.isClosure()) return false
       const applyMethod = node.methods.find(method => method.name === CLOSURE_EVALUATE_METHOD)
@@ -161,7 +158,7 @@ export const usesField = (node: Sentence | Body | NamedArgument | Field, field: 
     when(Variable)(node => usesField(node.value, field)),
     when(Return)(node => !!node.value && usesField(node.value, field)),
     when(Assignment)(node => node.variable.target === field || usesField(node.value, field)),
-    when(Reference)(node => node.target === field || (!!node.target && node.target.is(Field) && usesField(node.target, field))),
+    when(Reference)(node => node.target === field),
     when(Send)(node => usesField(node.receiver, field) || node.args.some(arg => usesField(arg, field))),
     when(If)(node => usesField(node.condition, field) || usesField(node.thenBody, field) || node.elseBody && usesField(node.elseBody, field)),
     when(New)(node => node.args.some(arg => usesField(arg, field))),
@@ -170,9 +167,7 @@ export const usesField = (node: Sentence | Body | NamedArgument | Field, field: 
     when(Try)(node => usesField(node.body, field) || node.catches.some(catchBlock => usesField(catchBlock.body, field)) || !!node.always && usesField(node.always, field)),
     when(Expression)(() => false),
     when(Body)(node => node.sentences.some(sentence => usesField(sentence, field))),
-    when(Field)(node => Array.isArray(node.value) && node.value.some(value => value === field)),
   )
-}
 
 // TODO: Import could offer a list of imported entities
 export const entityIsAlreadyUsedInImport = (target: Entity | undefined, entityName: string): boolean | undefined => target && match(target)(


### PR DESCRIPTION
## Resuelve

#124 

- actualmente no tomaba en cuenta métodos de un describe
- tampoco cuando inicializabas lists o sets en base a otras definiciones

## PRs relacionados

- [Language](https://github.com/uqbar-project/wollok-language/pull/179), agregamos clases de equivalencia para set, list y el método initialize de un describe, además de probar el caso donde tiene que detectar una variable sin usar en un wtest
