### PR TITLE
Fix import with collision

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wollok-ts",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wollok-ts",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
         "@types/parsimmon": "^1.10.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wollok-ts",
   "version": "4.1.1",
-  "wollokVersion": "3.2.2",
+  "wollokVersion": "3.2.3",
   "description": "TypeScript based Wollok language implementation",
   "repository": "https://github.com/uqbar-project/wollok-ts",
   "license": "MIT",

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,4 @@
-import { BOOLEAN_MODULE, CLOSURE_EVALUATE_METHOD, CLOSURE_MODULE, CLOSURE_TO_STRING_METHOD, EXCEPTION_MODULE, INFIX_OPERATORS, KEYWORDS, NUMBER_MODULE, OBJECT_MODULE, PREFIX_OPERATORS, STRING_MODULE, WOLLOK_BASE_PACKAGE } from './constants'
+import { BOOLEAN_MODULE, CLOSURE_EVALUATE_METHOD, CLOSURE_MODULE, CLOSURE_TO_STRING_METHOD, EXCEPTION_MODULE, INFIX_OPERATORS, KEYWORDS, NUMBER_MODULE, OBJECT_MODULE, PREFIX_OPERATORS, STRING_MODULE, TEST_FILE_EXTENSION, WOLLOK_BASE_PACKAGE } from './constants'
 import { cached, getPotentiallyUninitializedLazy, lazy } from './decorators'
 import { ConstructorFor, InstanceOf, is, last, List, mapObject, Mixable, MixinDefinition, MIXINS, isEmpty, notEmpty, TypeDefinition } from './extensions'
 import { GLOBAL_PACKAGES } from './linker'
@@ -333,9 +333,8 @@ export class Package extends Entity(Node) {
   @cached
   get sourceFileName(): string | undefined { return this.fileName ?? super.sourceFileName }
 
-  get isGlobalPackage(): boolean {
-    return GLOBAL_PACKAGES.includes(this.fullyQualifiedName)
-  }
+  get isGlobalPackage(): boolean { return GLOBAL_PACKAGES.includes(this.fullyQualifiedName) }
+  get isTestFile(): boolean { return this.sourceFileName?.endsWith(TEST_FILE_EXTENSION) ?? false }
 
   getNodeByQN<N extends Entity>(qualifiedName: Name): N {
     const node = this.getNodeOrUndefinedByQN<N>(qualifiedName)

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -452,7 +452,9 @@ export const shouldNotDuplicatePackageName = error<Package>(node =>
 sourceMapForNodeName)
 
 export const shouldNotUseSpecialCharactersInName = error<Package>(node =>
-  !node.fileName || node.fileName.match(/\./g)!.length === 1
+  !node.fileName ||
+    node.fileName.match(/([A-Za-z._/\d])/g)!.length === node.fileName.length 
+    && node.fileName.match(/\./g)!.length === 1
 , valuesForFileName,
 sourceMapForNodeName)
 

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -27,7 +27,7 @@ import { Assignment, Body, Catch, Class, Code, Describe, Entity, Expression, Fie
   Program, Reference, Return, Self, Send, Sentence, Singleton, SourceMap, Super, Test, Throw, Try, Variable } from '../model'
 import { allParents, assigns, assignsVariable, duplicatesLocalVariable, entityIsAlreadyUsedInImport, findMethod, finishesFlow, getContainer, getInheritedUninitializedAttributes, getReferencedModule, getUninitializedAttributesForInstantiation, getVariableContainer, hasDuplicatedVariable, inheritsCustomDefinition, isAlreadyUsedInImport, isBooleanLiteral, isBooleanMessage, isBooleanOrUnknownType, isEqualMessage, isGetter, isImplemented, isInitialized, isUninitialized, loopInAssignment, methodExists, methodIsImplementedInSuperclass, methodsCallingToSuper, referencesSingleton, returnsAValue, returnsValue, sendsMessageToAssert, superclassMethod, supposedToReturnValue, targetSupertypes, unusedVariable, usesReservedWords, valueFor } from '../helpers'
 import { sourceMapForBody, sourceMapForConditionInIf, sourceMapForNodeName, sourceMapForNodeNameOrFullNode, sourceMapForOnlyTest, sourceMapForOverrideMethod, sourceMapForUnreachableCode } from './sourceMaps'
-import { valuesForNodeName } from './values'
+import { valuesForFileName, valuesForNodeName } from './values'
 
 const { entries } = Object
 
@@ -451,6 +451,11 @@ export const shouldNotDuplicatePackageName = error<Package>(node =>
 , valuesForNodeName,
 sourceMapForNodeName)
 
+export const shouldNotUseSpecialCharactersInName = error<Package>(node =>
+  !node.fileName || node.fileName.match(/\./g)!.length === 1
+, valuesForFileName,
+sourceMapForNodeName)
+
 export const shouldCatchUsingExceptionHierarchy = error<Catch>(node => {
   const EXCEPTION_CLASS = node.environment.getNodeByFQN<Class>(EXCEPTION_MODULE)
   const exceptionType = node.parameterType.target
@@ -533,7 +538,7 @@ const validationsByKind = (node: Node): Record<string, Validation<any>> => match
   when(Import)(() => ({ shouldNotImportSameFile, shouldNotImportMoreThanOnce })),
   when(Body)(() => ({ shouldNotBeEmpty })),
   when(Catch)(() => ({ shouldCatchUsingExceptionHierarchy, catchShouldBeReachable })),
-  when(Package)(() => ({ shouldNotDuplicatePackageName })),
+  when(Package)(() => ({ shouldNotDuplicatePackageName, shouldNotUseSpecialCharactersInName })),
   when(Program)(() => ({ nameShouldNotBeKeyword, shouldNotUseReservedWords, shouldMatchFileExtension, shouldNotDuplicateEntities })),
   when(Test)(() => ({ shouldHaveNonEmptyName, shouldNotMarkMoreThanOneOnlyTest, shouldHaveAssertInTest, shouldMatchFileExtension, shouldHaveDifferentName })),
   when(Class)(() => ({ nameShouldBeginWithUppercase, nameShouldNotBeKeyword, shouldNotHaveLoopInHierarchy, linearizationShouldNotRepeatNamedArguments, shouldNotDefineMoreThanOneSuperclass, superclassShouldBeLastInLinearization, shouldNotDuplicateGlobalDefinitions, shouldNotDuplicateVariablesInLinearization, shouldImplementAllMethodsInHierarchy, shouldNotUseReservedWords, shouldNotDuplicateEntities })),

--- a/src/validator/values.ts
+++ b/src/validator/values.ts
@@ -1,3 +1,4 @@
 import { Node } from '../model'
 
 export const valuesForNodeName = (node: Node & { name?: string }): string[] => [node.name ?? '']
+export const valuesForFileName = (node: Node): string[] => [node.sourceFileName ?? '']

--- a/test/linker.test.ts
+++ b/test/linker.test.ts
@@ -724,6 +724,20 @@ describe('Wollok linker', () => {
       env.getNodeByFQN<Package>('g').members.should.have.length(2)
     })
 
+    it('should import wlk files on fqn collisions', () => {
+      const env = link([
+        new Package({ fileName: 'p.wtest', name: 'p' }), // First declare the test
+        new Package({ fileName: 'p.wlk', name: 'p' }),
+        new Package({
+          name: 'g',
+          imports: [new Import({ entity: new Reference({ name: 'p' }) })],
+        }),
+      ], MINIMAL_LANG)
+      const entity = env.getNodeByFQN<Package>('p')
+      entity.fileName!.should.be.eql('p.wlk')
+      env.getNodeByFQN<Package>('g').imports[0].entity.should.target(entity)
+    })
+
     it('should not crash with missing reference in imports', () =>
       link([
         new Package({

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -26,7 +26,7 @@ export function allExpectations(parentNode: Node): Map<Node, Annotation[]> {
       const path = expectedProblem.args['path']
       const expectedNode: Node = path ? (node as any)[path as any] : node
       if (!allExpectations.has(expectedNode)) allExpectations.set(expectedNode, [])
-            allExpectations.get(expectedNode)!.push(expectedProblem)
+      allExpectations.get(expectedNode)!.push(expectedProblem)
     })
   })
   return allExpectations
@@ -34,7 +34,13 @@ export function allExpectations(parentNode: Node): Map<Node, Annotation[]> {
 
 export const matchesExpectationProblem = (problem: Problem, annotatedNode: Node, expected: Annotation): boolean => {
   const code = expected.args['code']!
-  return problem.code === code && !!annotatedNode.sourceMap?.includes(problem.sourceMap!)
+  return problem.code === code && matchSourceMap(annotatedNode.sourceMap, problem.sourceMap)
+}
+
+
+function matchSourceMap(annotatedSourceMap?: SourceMap, problemSourceMap?: SourceMap): boolean {
+  return annotatedSourceMap === undefined && problemSourceMap === undefined
+    || !!problemSourceMap && !!annotatedSourceMap?.includes(problemSourceMap)
 }
 
 export const errorLocation = (node: Node | Problem): string => `${node.sourceMap}`

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -12,7 +12,7 @@ describe('Wollok Validations', () => {
 
   buildEnvironmentForEachFile(TESTS_PATH, (filePackage, fileContent) => {
 
-    it(filePackage.name, () => {
+    it(filePackage.fileName!, () => {
       const allProblems = validate(filePackage)
       const expectations = allExpectations(filePackage)
 


### PR DESCRIPTION
Fix https://github.com/uqbar-project/wollok-ts/issues/236
Maybe https://github.com/uqbar-project/wollok-ts/issues/207
Gran parte de https://github.com/uqbar-project/wollok-ts/issues/166 (faltan algunos detalles, podemos abrir otros issues para seguirla...)

Lo que hice fue:
- Al linkear los imports, si colisionan las referencias, los `.wlk` ganan sobre los `.wtest`. Sino deja el primero que encuentra (esto es para evitar que definiciones locales se pisen con globales).
- Agregué una validación para no tener `.` en los nombres de archivos (que rompen los fqn).
- Para testear, tuve que tocar el parser para que no rompan archivos con solo metadata (comentarios o annotations)

#### Test en https://github.com/uqbar-project/wollok-language/pull/180
