### PR TITLE
Refactorización de onCollide

### DIFF
--- a/src/wre/game.ts
+++ b/src/wre/game.ts
@@ -41,14 +41,9 @@ const game: Natives = {
         const roundedX = round(x)
         const roundedY = round(y)
         for(const visual of visuals.innerCollection!) {
-          // si el visual tiene el atributo 'position' intentamos usarlo
-          // esto ahorra mucho tiempo
-          let otherPosition = visual.get('position')
+          const metodo = visual.module.lookupMethod('position', 0)!
 
-          // de lo contrario llamamos al método position() del visual
-          if(otherPosition == undefined) {
-            otherPosition = yield* this.send('position', visual)
-          }
+          const otherPosition = metodo.isSynthetic ? visual.get('position') :yield* this.send('position', visual)
 
           const otherX = otherPosition?.get('x')?.innerNumber
           const otherY = otherPosition?.get('y')?.innerNumber

--- a/src/wre/game.ts
+++ b/src/wre/game.ts
@@ -41,7 +41,11 @@ const game: Natives = {
         const roundedX = round(x)
         const roundedY = round(y)
         for(const visual of visuals.innerCollection!) {
+          // si el visual tiene el atributo 'position' intentamos usarlo
+          // esto ahorra mucho tiempo
           let otherPosition = visual.get('position')
+
+          // de lo contrario llamamos al método position() del visual
           if(otherPosition == undefined) {
             otherPosition = yield* this.send('position', visual)
           }

--- a/src/wre/game.ts
+++ b/src/wre/game.ts
@@ -41,9 +41,12 @@ const game: Natives = {
         const roundedX = round(x)
         const roundedY = round(y)
         for(const visual of visuals.innerCollection!) {
-          const metodo = visual.module.lookupMethod('position', 0)!
 
-          const otherPosition = metodo.isSynthetic ? visual.get('position') :yield* this.send('position', visual)
+          // Every visual understand position(), it is checked in addVisual(visual).
+          // Avoid to invoke method position() for optimisation reasons. 
+          //    -> If method isSynthetic then it is a getter, we can access to the field directly
+          const method = visual.module.lookupMethod('position', 0)!
+          const otherPosition = metodo.isSynthetic ? visual.get('position') :yield* this.invoke(method, visual)
 
           const otherX = otherPosition?.get('x')?.innerNumber
           const otherY = otherPosition?.get('y')?.innerNumber

--- a/src/wre/game.ts
+++ b/src/wre/game.ts
@@ -43,10 +43,10 @@ const game: Natives = {
         for(const visual of visuals.innerCollection!) {
 
           // Every visual understand position(), it is checked in addVisual(visual).
-          // Avoid to invoke method position() for optimisation reasons. 
+          // Avoid to invoke method position() for optimisation reasons.
           //    -> If method isSynthetic then it is a getter, we can access to the field directly
           const method = visual.module.lookupMethod('position', 0)!
-          const otherPosition = metodo.isSynthetic ? visual.get('position') :yield* this.invoke(method, visual)
+          const otherPosition = method.isSynthetic ? visual.get('position') :yield* this.invoke(method, visual)
 
           const otherX = otherPosition?.get('x')?.innerNumber
           const otherY = otherPosition?.get('y')?.innerNumber
@@ -72,15 +72,11 @@ const game: Natives = {
 
     *colliders(self: RuntimeObject, visual: RuntimeObject): Execution<RuntimeValue> {
       visual.assertIsNotNull()
-      // const tsInicio = performance.now()
 
       const position = (yield* this.send('position', visual))!
-
       const visualsAtPosition: RuntimeObject = (yield* this.send('getObjectsIn', self, position))!
 
       yield* this.send('remove', visualsAtPosition, visual)
-      // const tsFin = performance.now()
-      // this.console.log("colliders", tsFin- tsInicio)
 
       return visualsAtPosition
     },

--- a/src/wre/game.ts
+++ b/src/wre/game.ts
@@ -36,11 +36,16 @@ const game: Natives = {
       const x = position.get('x')?.innerNumber
       const y = position.get('y')?.innerNumber
 
+
       if(x != undefined && y != undefined) {
         const roundedX = round(x)
         const roundedY = round(y)
         for(const visual of visuals.innerCollection!) {
-          const otherPosition = yield* this.send('position', visual)
+          let otherPosition = visual.get('position')
+          if(otherPosition == undefined) {
+            otherPosition = yield* this.send('position', visual)
+          }
+
           const otherX = otherPosition?.get('x')?.innerNumber
           const otherY = otherPosition?.get('y')?.innerNumber
 
@@ -50,6 +55,7 @@ const game: Natives = {
             result.push(visual)
         }
       }
+
       return yield* this.list(...result)
     },
 
@@ -64,11 +70,15 @@ const game: Natives = {
 
     *colliders(self: RuntimeObject, visual: RuntimeObject): Execution<RuntimeValue> {
       visual.assertIsNotNull()
+      // const tsInicio = performance.now()
 
       const position = (yield* this.send('position', visual))!
+
       const visualsAtPosition: RuntimeObject = (yield* this.send('getObjectsIn', self, position))!
 
       yield* this.send('remove', visualsAtPosition, visual)
+      // const tsFin = performance.now()
+      // this.console.log("colliders", tsFin- tsInicio)
 
       return visualsAtPosition
     },


### PR DESCRIPTION
este PR es para intentar mejorar el tiempo de respuesta de los eventos de colisión (https://github.com/uqbar-project/wollok-ts-cli/issues/157)

El cambio consiste en reemplazar, cuando se pueda, la llamada a `yield* this.send('position', visual)` por un `visual.get('position')` en el método `getObjectsIn()` que es llamado por los eventos onCollide y whenCollide
Se notó una diferencia importante de velocidad entre el primer método y el segundo. En el entorno de pruebas, con unos cientos de visuales, cada llamada a `getObjectsIn()` pasó de unos 30ms a 0.5ms entre un método y otro

El problema es que el primer método sólo se puede utilizar para visuales que tengan `position` definido como `property`, por lo que se hace un chequeo preguntando si el método `position()` es sintético, si es así, se puede utilizar el `get()`, sino se utiliza el método original (`send()`)


