### PR TITLE
Imports xtext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wollok-ts",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wollok-ts",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "license": "MIT",
       "dependencies": {
         "@types/parsimmon": "^1.10.8",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -69,7 +69,7 @@ export const finishesFlow = (sentence: Sentence, node: Node): boolean => {
   const lastLineOnMethod = parent.is(Body) ? last(parent.sentences) : undefined
   const returnCondition = (sentence.is(Return) && lastLineOnMethod !== node && lastLineOnMethod?.is(Return) || lastLineOnMethod?.is(Throw)) ?? false
   // TODO: For Send, consider if expression returns a value
-  return sentence.is(Variable) || sentence.is(Throw) || sentence.is(Send) || sentence.is(Assignment) || sentence.is(If) || returnCondition
+  return sentence.is(Variable) || sentence.is(Throw) || sentence.is(Send) || sentence.is(Super) || sentence.is(Assignment) || sentence.is(If) || returnCondition
 }
 
 export const getVariableContainer = (node: Node): CodeContainer | undefined =>

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -108,11 +108,13 @@ export const assignScopes = (environment: Environment): void => {
     if (node.is(Package)) {
       for (const importNode of node.imports) {
         const entity = importNode.scope.resolve<Entity>(importNode.entity.name)
+        if (!entity) break
 
-        if (entity) node.scope.include(importNode.isGeneric
-          ? new LocalScope(undefined, ...entity.scope.localContributions())
-          : new LocalScope(undefined, [entity.name!, entity])
-        )
+        const contributions: [string, Node][] = importNode.isGeneric
+          ? entity.is(Package) && entity.isImportable ? entity.scope.localContributions() : []
+          : [[entity.name!, entity]]
+
+        node.scope.include(new LocalScope(undefined, ...contributions))
       }
     }
 

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -108,7 +108,7 @@ export const assignScopes = (environment: Environment): void => {
     if (node.is(Package)) {
       for (const importNode of node.imports) {
         const entity = importNode.scope.resolve<Entity>(importNode.entity.name)
-        if (!entity) break
+        if (!entity) break // If there is no entity with the name the validator will create the problem
 
         const contributions: [string, Node][] = importNode.isGeneric
           ? entity.is(Package) && entity.isImportable ? entity.scope.localContributions() : []

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,4 @@
-import { BOOLEAN_MODULE, CLOSURE_EVALUATE_METHOD, CLOSURE_MODULE, CLOSURE_TO_STRING_METHOD, EXCEPTION_MODULE, INFIX_OPERATORS, KEYWORDS, NUMBER_MODULE, OBJECT_MODULE, PREFIX_OPERATORS, STRING_MODULE, TEST_FILE_EXTENSION, WOLLOK_BASE_PACKAGE } from './constants'
+import { BOOLEAN_MODULE, CLOSURE_EVALUATE_METHOD, CLOSURE_MODULE, CLOSURE_TO_STRING_METHOD, EXCEPTION_MODULE, INFIX_OPERATORS, KEYWORDS, NUMBER_MODULE, OBJECT_MODULE, PREFIX_OPERATORS, STRING_MODULE, TEST_FILE_EXTENSION, WOLLOK_BASE_PACKAGE, WOLLOK_FILE_EXTENSION } from './constants'
 import { cached, getPotentiallyUninitializedLazy, lazy } from './decorators'
 import { ConstructorFor, InstanceOf, is, last, List, mapObject, Mixable, MixinDefinition, MIXINS, isEmpty, notEmpty, TypeDefinition } from './extensions'
 import { GLOBAL_PACKAGES } from './linker'
@@ -335,6 +335,8 @@ export class Package extends Entity(Node) {
 
   get isGlobalPackage(): boolean { return GLOBAL_PACKAGES.includes(this.fullyQualifiedName) }
   get isTestFile(): boolean { return this.sourceFileName?.endsWith(TEST_FILE_EXTENSION) ?? false }
+  get isWLKFile(): boolean { return this.sourceFileName?.endsWith(WOLLOK_FILE_EXTENSION) ?? false }
+  get isImportable(): boolean { return this.isWLKFile || !this.sourceFileName }
 
   getNodeByQN<N extends Entity>(qualifiedName: Name): N {
     const node = this.getNodeOrUndefinedByQN<N>(qualifiedName)

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -145,6 +145,11 @@ export const shouldUseSelfAndNotSingletonReference = warning<Reference<Node>>(no
   return !target || !target.is(Singleton) || !node.ancestors.includes(target)
 })
 
+export const shouldReferenceToObjects = error<Reference<Node>>(node => {
+  const target = node.target
+  return !target || !target.is(Package) || node.parent.is(Import)
+})
+
 export const shouldOnlyInheritFromMixin = error<Mixin>(node => node.supertypes.every(parent => {
   const target = parent.reference.target
   return !target || target.is(Mixin)
@@ -531,7 +536,7 @@ const validationsByKind = (node: Node): Record<string, Validation<any>> => match
   when(Method)(() => ({ onlyLastParameterCanBeVarArg, nameShouldNotBeKeyword, methodShouldHaveDifferentSignature, shouldNotOnlyCallToSuper, shouldUseOverrideKeyword, possiblyReturningBlock, shouldNotUseOverride, shouldMatchSuperclassReturnValue, shouldNotDefineNativeMethodsOnUnnamedSingleton, overridingMethodShouldHaveABody, getterMethodShouldReturnAValue, shouldHaveBody })),
   when(Variable)(() => ({ nameShouldBeginWithLowercase, nameShouldNotBeKeyword, shouldNotAssignToItselfInDeclaration, shouldNotDuplicateLocalVariables, shouldNotDuplicateGlobalDefinitions, shouldNotDefineGlobalMutableVariables, shouldNotUseReservedWords, shouldInitializeGlobalReference, shouldDefineConstInsteadOfVar, shouldNotDuplicateEntities, shouldInitializeConst })),
   when(Assignment)(() => ({ shouldNotAssignToItself, shouldNotReassignConst })),
-  when(Reference)(() => ({ missingReference, shouldUseSelfAndNotSingletonReference })),
+  when(Reference)(() => ({ missingReference, shouldUseSelfAndNotSingletonReference, shouldReferenceToObjects })),
   when(Self)(() => ({ shouldNotUseSelf })),
   when(New)(() => ({ shouldNotInstantiateAbstractClass, shouldPassValuesToAllAttributes })),
   when(Send)(() => ({ shouldNotCompareAgainstBooleanLiterals, shouldNotCompareEqualityOfSingleton, shouldUseBooleanValueInLogicOperation, methodShouldExist, codeShouldBeReachable, shouldNotDefineUnnecessaryCondition, shouldNotUseVoidMethodAsValue })),

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -447,7 +447,7 @@ export const shouldInitializeConst = error<Variable>(node =>
 sourceMapForNodeName)
 
 export const shouldNotDuplicatePackageName = error<Package>(node =>
-  !node.siblings().some(sibling => sibling.is(Package) && sibling.name == node.name)
+  !node.siblings().some(sibling => sibling.is(Package) && sibling.name == node.name && sibling.sourceFileName == node.sourceFileName)
 , valuesForNodeName,
 sourceMapForNodeName)
 


### PR DESCRIPTION
Fix https://github.com/uqbar-project/wollok-ts/issues/257
Fix https://github.com/uqbar-project/wollok-ts/issues/253

### Relacionado a https://github.com/uqbar-project/wollok-ts/issues/241

Como no llegamos a consenso sobre las extensiones de archivos, decidí dejar los importas al igual que funcionaban en Xtext:
- Solamente se pueden importar archivos `.wlk`
- No valida archivos con el mismo nombre (pero distinta extensión).
- Así que por ahora ese issue queda pendiente

#### Tests en https://github.com/uqbar-project/wollok-language/pull/193

------

Después de estos cambios, este ejercicio de **superpoderoses** (que me _encanta_!) funca piola de una:
https://github.com/obj1unq/2021s1-simulacro-superpoderoses-lgassman