### PR TITLE
Cache float numbers too

### DIFF
--- a/src/interpreter/runtimeModel.ts
+++ b/src/interpreter/runtimeModel.ts
@@ -661,13 +661,11 @@ export class Evaluation {
       const isRound = isInteger(value)
       const preciseValue = isRound ? value : Number(value.toFixed(DECIMAL_PRECISION))
 
-      if (isRound) {
-        const existing = this.numberCache.get(preciseValue)?.deref()
-        if (existing) return existing
-      }
+      const existing = this.numberCache.get(preciseValue)?.deref()
+      if (existing) return existing
 
       const instance = new RuntimeObject(this.environment.getNodeByFQN(NUMBER_MODULE), this.rootFrame, preciseValue)
-      if (isRound) this.numberCache.set(preciseValue, new WeakRef(instance))
+      this.numberCache.set(preciseValue, new WeakRef(instance))
       return instance
     }
 


### PR DESCRIPTION
Fix https://github.com/uqbar-project/wollok-ts/issues/276

El problema era que solo se estaban cacheando los enteros.

Lo cambiamos para que cachee todos los números que se interpretan... espero que no tenga daños colaterales :P

#### Tests: https://github.com/uqbar-project/wollok-language/pull/198