### PR TITLE
Error en imports que se hacen desde diferentes packages (el orden causa error)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:game": "mocha --parallel -r ts-node/register/transpile-only test/**/game.test.ts",
     "test:dynamicDiagram": "mocha --parallel -r ts-node/register/transpile-only test/dynamicDiagram.test.ts",
     "test:helpers": "mocha --parallel -r ts-node/register/transpile-only test/helpers.test.ts",
-    "test:interpreter": "mocha --parallel -r ts-node/register/transpile-only test/interpreter.test.ts",
+    "test:interpreter": "mocha -r ts-node/register/transpile-only test/interpreter.test.ts",
     "test:linker": "mocha --parallel -r ts-node/register/transpile-only test/linker.test.ts",
     "test:messageReporter": "mocha --parallel -r ts-node/register/transpile-only test/messageReporter.test.ts",
     "test:model": "mocha --parallel -r ts-node/register/transpile-only test/model.test.ts",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:game": "mocha --parallel -r ts-node/register/transpile-only test/**/game.test.ts",
     "test:dynamicDiagram": "mocha --parallel -r ts-node/register/transpile-only test/dynamicDiagram.test.ts",
     "test:helpers": "mocha --parallel -r ts-node/register/transpile-only test/helpers.test.ts",
-    "test:interpreter": "mocha -r ts-node/register/transpile-only test/interpreter.test.ts",
+    "test:interpreter": "mocha --parallel -r ts-node/register/transpile-only test/interpreter.test.ts",
     "test:linker": "mocha --parallel -r ts-node/register/transpile-only test/linker.test.ts",
     "test:messageReporter": "mocha --parallel -r ts-node/register/transpile-only test/messageReporter.test.ts",
     "test:model": "mocha --parallel -r ts-node/register/transpile-only test/model.test.ts",

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -92,11 +92,6 @@ export const assignScopes = (root: Node): void => {
       ? parent?.parent.scope
       : parent?.scope
     assign(node, { scope: new LocalScope(containerScope) })
-
-    if (node.name === 'Medico') {
-      console.info(canBeReferenced(node), node.name, node.scope)
-    }
-
     parent?.scope?.register(...scopeContribution(node))
   })
 
@@ -120,7 +115,9 @@ export const assignScopes = (root: Node): void => {
         node.scope.include(new LocalScope(undefined, ...contributions))
       }
     }
+  })
 
+  root.forEach((node, _parent) => {
     if (node.is(Module)) {
       node.scope.include(...node.hierarchy.slice(1).map(supertype => supertype.scope))
     }

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -93,6 +93,10 @@ export const assignScopes = (root: Node): void => {
       : parent?.scope
     assign(node, { scope: new LocalScope(containerScope) })
 
+    if (node.name === 'Medico') {
+      console.info(canBeReferenced(node), node.name, node.scope)
+    }
+
     parent?.scope?.register(...scopeContribution(node))
   })
 

--- a/test/interpreter.test.ts
+++ b/test/interpreter.test.ts
@@ -2,7 +2,7 @@ import { expect, should, use } from 'chai'
 import { restore } from 'sinon'
 import sinonChai from 'sinon-chai'
 import { EXCEPTION_MODULE, Evaluation, REPL, WRENatives, buildEnvironment } from '../src'
-import { DirectedInterpreter, interprete, Interpreter, getStackTraceSanitized } from '../src/interpreter/interpreter'
+import { DirectedInterpreter, getStackTraceSanitized, interprete, Interpreter } from '../src/interpreter/interpreter'
 import link from '../src/linker'
 import { Body, Class, Field, Literal, Method, Package, ParameterizedType, Reference, Return, Send, Singleton, SourceIndex, SourceMap } from '../src/model'
 import { WREEnvironment } from './utils'
@@ -270,6 +270,68 @@ describe('Wollok Interpreter', () => {
       it('for closure', () => {
         checkSuccessfulResult('{1 + 2}', '{1 + 2}')
       })
+
+      it('should be able to execute sentences related to a hierarchy defined in different packages', () => {
+        const replEnvironment = buildEnvironment([{
+          name: 'jefeDeDepartamento.wlk', content: `
+          import medico.*
+
+          // con ésto falla
+          class Jefe inherits Medico {
+          // si comento la línea de arriba y utilizo ésto no falla
+          // class Jefe {
+            const subordinados = #{}
+
+            override method atenderA(unaPersona) {
+              subordinados.anyOne().atenderA(unaPersona)
+            }
+          }
+          `,
+        }, {
+          name: 'medico.wlk', content: `
+          import persona.*
+
+          class Medico inherits Persona {
+            const dosis
+
+            override method contraerEnfermedad(unaEnfermedad) {
+              super(unaEnfermedad)
+              self.atenderA(self)
+            }
+            method atenderA(unaPersona) {
+              unaPersona.recibirMedicamento(dosis)
+            }
+
+          }
+          `,
+        }, {
+          name: 'persona.wlk', content: `
+          class Persona {
+            const enfermedades = []
+            
+            method contraerEnfermedad(unaEnfermedad) {
+
+              enfermedades.add(unaEnfermedad)
+            }
+
+            method saludar() = "hola"
+          }
+          `,
+        }, {
+          name: REPL, content: `
+          import medico.*
+
+          object testit {
+            method test() = new Medico(dosis = 200).saludar()
+          }
+          `,
+        }])
+        interpreter = new Interpreter(Evaluation.build(replEnvironment, WRENatives))
+        const { error } = interprete(interpreter, 'testit.test()')
+        console.info(error)
+        expect(error).to.be.undefined
+      })
+
     })
 
     describe('sanitize stack trace', () => {

--- a/test/interpreter.test.ts
+++ b/test/interpreter.test.ts
@@ -271,7 +271,7 @@ describe('Wollok Interpreter', () => {
         checkSuccessfulResult('{1 + 2}', '{1 + 2}')
       })
 
-      it('should be able to execute sentences related to a hierarchy defined in different packages', () => {
+      it.only('should be able to execute sentences related to a hierarchy defined in different packages', () => {
         const replEnvironment = buildEnvironment([{
           name: 'jefeDeDepartamento.wlk', content: `
           import medico.*
@@ -328,7 +328,7 @@ describe('Wollok Interpreter', () => {
         }])
         interpreter = new Interpreter(Evaluation.build(replEnvironment, WRENatives))
         const { error } = interprete(interpreter, 'testit.test()')
-        console.info(error)
+        // console.info(error)
         expect(error).to.be.undefined
       })
 

--- a/test/interpreter.test.ts
+++ b/test/interpreter.test.ts
@@ -276,7 +276,6 @@ describe('Wollok Interpreter', () => {
           name: 'jefeDeDepartamento.wlk', content: `
           import medico.*
 
-          // con ésto falla
           class Jefe inherits Medico {
             const subordinados = #{}
 

--- a/test/linker.test.ts
+++ b/test/linker.test.ts
@@ -474,7 +474,7 @@ describe('Wollok linker', () => {
           members: [
             new Class({
               name: 'C',
-              supertypes: [new ParameterizedType({ reference: new Reference({ name: 'bbb.B' }) })],
+              supertypes: [new ParameterizedType({ reference: new Reference({ name: 'B' }) })],
               members: [
                 new Method({
                   name: 'm2',
@@ -492,7 +492,7 @@ describe('Wollok linker', () => {
           members: [
             new Class({
               name: 'B',
-              supertypes: [new ParameterizedType({ reference: new Reference({ name: 'zzz.A' }) })],
+              supertypes: [new ParameterizedType({ reference: new Reference({ name: 'A' }) })],
               members: [
                 new Method({
                   name: 'm',


### PR DESCRIPTION
Sobre el problema reportado en https://github.com/uqbar-project/wollok-ts/issues/308, me tomó mucho laburo tratar de reproducirlo, pero acá dejo dos tests:

- el del linker que pasa irremediablemente
- el del interpreter, que rompe cuando vos tenés una jerarquía, cuando vos hacés

```wollok
// en un package
import B.*
class A inherits B {}

// en otro package
import C.*
class B inherits C {}

// y en otro package
class C {
  method bla()
}
```

no funciona `new B().bla()` (dice que no lo entiende). Si en cambio hacés:

```wollok
// en un package
import B.*
class A{}

// en otro package
import C.*
class B inherits C {}

// y en otro package
class C {
  method bla()
}
```

funciona perfectamente.

@ivojawer @PalumboN , me gustaría verlo en nuestras sesiones de los martes.