### PR TITLE
Fix de shouldUseOverrideKeyword para una property

### DIFF
--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -156,7 +156,7 @@ export const shouldOnlyInheritFromMixin = error<Mixin>(node => node.supertypes.e
 }))
 
 export const shouldUseOverrideKeyword = warning<Method>(node =>
-  node.isOverride || !superclassMethod(node) || node.name == INITIALIZE_METHOD
+  node.isOverride || node.isSynthetic || !superclassMethod(node) || node.name == INITIALIZE_METHOD
 )
 
 export const possiblyReturningBlock = warning<Method>(node => {


### PR DESCRIPTION
No mucho más para agregar, faltaba chequear que el método fuera synthetic (lo que significa que se generó, en este caso por ser una property).