### PR TITLE
Fix #304 Super inside closure

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -442,7 +442,10 @@ export const getNodeDefinition = (environment: Environment) => (node: Node): Nod
 }
 
 export const superMethodDefinition = (superNode: Super, methodModule: Module): Method | undefined => {
-  const currentMethod = superNode.ancestors.find(is(Method))!
+  function isValidMethod(node: Node): node is Method {
+    return node.is(Method) && node.name !== CLOSURE_EVALUATE_METHOD
+  }
+  const currentMethod = superNode.ancestors.find(isValidMethod)!
   return methodModule.lookupMethod(currentMethod.name, superNode.args.length, { lookupStartFQN: currentMethod.parent.fullyQualifiedName })
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import { BOOLEAN_MODULE, CLOSURE_EVALUATE_METHOD, CLOSURE_TO_STRING_METHOD, INITIALIZE_METHOD, KEYWORDS, NUMBER_MODULE, OBJECT_MODULE, STRING_MODULE, VOID_WKO, WOLLOK_BASE_PACKAGE } from './constants'
+import { BOOLEAN_MODULE, CLOSURE_EVALUATE_METHOD, CLOSURE_MODULE, CLOSURE_TO_STRING_METHOD, INITIALIZE_METHOD, KEYWORDS, NUMBER_MODULE, OBJECT_MODULE, STRING_MODULE, VOID_WKO, WOLLOK_BASE_PACKAGE } from './constants'
 import { getPotentiallyUninitializedLazy } from './decorators'
 import { count, is, isEmpty, last, List, match, notEmpty, otherwise, valueAsListOrEmpty, when, excludeNullish } from './extensions'
 import { RuntimeObject, RuntimeValue } from './interpreter/runtimeModel'
@@ -443,7 +443,7 @@ export const getNodeDefinition = (environment: Environment) => (node: Node): Nod
 
 export const superMethodDefinition = (superNode: Super, methodModule: Module): Method | undefined => {
   function isValidMethod(node: Node): node is Method {
-    return node.is(Method) && node.name !== CLOSURE_EVALUATE_METHOD
+    return node.is(Method) && node.name !== CLOSURE_EVALUATE_METHOD && node.parent.fullyQualifiedName !== CLOSURE_MODULE
   }
   const currentMethod = superNode.ancestors.find(isValidMethod)!
   return methodModule.lookupMethod(currentMethod.name, superNode.args.length, { lookupStartFQN: currentMethod.parent.fullyQualifiedName })

--- a/test/interpreter.test.ts
+++ b/test/interpreter.test.ts
@@ -541,7 +541,6 @@ describe('Wollok Interpreter', () => {
       expect(errored).to.be.false
     })
 
-
   })
 
   describe('DirectedInterpreter', () => {


### PR DESCRIPTION
El closure se define como un Method, eso causa que cuando estás en el contexto de un super si buscás el primer método de los ancestors te traiga el mismo closure y quiera ejecutar `<apply>` dentro del objeto receptor. Como `<apply>` es un pseudo método interno, filtramos los métodos construidos de esta manera y super funciona de la manera esperada.

Tiene su correspondiente sanity test: https://github.com/uqbar-project/wollok-language/pull/224