### PR TITLE
Fix parser multiline comment

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:typeSystem": "mocha --parallel -r ts-node/register/transpile-only test/typeSystem*.test.ts",
     "test:wtest": "mocha --delay -t 10000 -r ts-node/register/transpile-only test/wtest.ts",
     "test:printer": "mocha --parallel -r ts-node/register/transpile-only test/printer.test.ts",
-    "test:parser": "mocha --parallel -r ts-node/register/transpile-only test/parser.test.ts",
+    "test:parser": "mocha -r ts-node/register/transpile-only test/parser.test.ts",
     "lint:fix": "eslint . --fix",
     "validate:wollokVersion": "ts-node scripts/validateWollokVersion.ts",
     "prepublishOnly": "npm run validate:wollokVersion && npm run build && npm test",

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -234,6 +234,43 @@ describe('Wollok parser', () => {
           .and.be.tracedTo(0, 124)
       })
 
+      it.only('ESTE ES EL QUE ROMPE multiline comments before many members with body expressions', () => {
+        `
+        class String {
+          /**
+           * comment
+           */
+          method words() = 2
+
+          /**
+           * another comment
+           */
+          method capitalize() {
+            return 1
+          }
+        }`.should.be.parsedBy(parser).into(new Class({
+            name: 'String',
+            metadata: [],
+            members: [
+              new Method({
+                name: 'words',
+                body: new Body({ sentences: [new Return({ value: new Literal({ value: 2 }) })] }),
+                metadata: [
+                  new Annotation('comment', { text: '/**\n           * comment\n           */', position: 'start' }),
+                ],
+              }),
+              new Method({
+                name: 'capitalize',
+                body: new Body({ sentences: [new Return({ value: new Literal({ value: 1 }) })] }),
+                metadata: [
+                  new Annotation('comment', { text: '/**\n           * another comment\n           */', position: 'start' }),
+                ],
+              }),
+            ],
+          }))
+          //.and.be.tracedTo(0, 233)
+      })
+
       it('comments with block closures', () => {
         `class c { 
           //some comment

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,6 +1,6 @@
 import { should, use } from 'chai'
 import { LIST_MODULE, SET_MODULE } from '../src'
-import { Annotation, Assignment, Body, Catch, Class, Closure, Describe, Field, If, Import, Literal, Method, Mixin, NamedArgument, New, Package, Parameter, ParameterizedType, Program, Reference, Return, Send, Singleton, SourceIndex, Super, Test, Throw, Try, Variable } from '../src/model'
+import { Annotation, Assignment, Body, Catch, Class, Closure, Describe, Field, If, Import, Literal, Method, Mixin, NamedArgument, New, Package, Parameter, ParameterizedType, Program, Reference, Return, Self, Send, Singleton, SourceIndex, Super, Test, Throw, Try, Variable } from '../src/model'
 import * as parse from '../src/parser'
 import { parserAssertions } from './assertions'
 
@@ -50,8 +50,10 @@ describe('Wollok parser', () => {
         .should.be.parsedBy(parse.Variable).into(new Variable({
           name: 'a',
           isConstant: true,
-          value: new Literal({ value: 1 }),
-          metadata: [new Annotation('comment', { text: '//some comment', position: 'end' })],
+          value: new Literal({
+            value: 1,
+            metadata: [new Annotation('comment', { text: '//some comment', position: 'end' })],
+          }),
         }))
     })
 
@@ -63,8 +65,10 @@ describe('Wollok parser', () => {
             new Variable({
               name: 'a',
               isConstant: true,
-              value: new Literal({ value: 1 }),
-              metadata: [new Annotation('comment', { text: '//some comment', position: 'end' })],
+              value: new Literal({
+                value: 1,
+                metadata: [new Annotation('comment', { text: '//some comment', position: 'end' })],
+              }),
             }),
           ],
         }))
@@ -234,41 +238,43 @@ describe('Wollok parser', () => {
           .and.be.tracedTo(0, 124)
       })
 
-      it.only('ESTE ES EL QUE ROMPE multiline comments before many members with body expressions', () => {
-        `
-        class String {
-          /**
-           * comment
-           */
-          method words() = 2
+      it('comments before many members with body expressions with send', () => {
+        `class c { 
+          //some comment
+          method m1() = self.m2()
 
-          /**
-           * another comment
-           */
-          method capitalize() {
-            return 1
-          }
+          //other comment
+          method m2() = 2
         }`.should.be.parsedBy(parser).into(new Class({
-            name: 'String',
+            name: 'c',
             metadata: [],
             members: [
               new Method({
-                name: 'words',
-                body: new Body({ sentences: [new Return({ value: new Literal({ value: 2 }) })] }),
+                name: 'm1',
+                body: new Body({
+                  sentences: [
+                    new Return({
+                      value: new Send({
+                        receiver: new Self(),
+                        message: 'm2',
+                      }),
+                    }),
+                  ],
+                }),
                 metadata: [
-                  new Annotation('comment', { text: '/**\n           * comment\n           */', position: 'start' }),
+                  new Annotation('comment', { text: '//some comment', position: 'start' }),
                 ],
               }),
               new Method({
-                name: 'capitalize',
-                body: new Body({ sentences: [new Return({ value: new Literal({ value: 1 }) })] }),
+                name: 'm2',
+                body: new Body({ sentences: [new Return({ value: new Literal({ value: 2 }) })] }),
                 metadata: [
-                  new Annotation('comment', { text: '/**\n           * another comment\n           */', position: 'start' }),
+                  new Annotation('comment', { text: '//other comment', position: 'start' }),
                 ],
               }),
             ],
           }))
-          //.and.be.tracedTo(0, 233)
+          .and.be.tracedTo(0, 132)
       })
 
       it('comments with block closures', () => {

--- a/test/printer.test.ts
+++ b/test/printer.test.ts
@@ -146,8 +146,7 @@ describe('Wollok Printer', () => {
           // comentario
           const a = 1
           // other comment but this comment is actually very veeeeeeeeeeeeery veeeeeeeeeery long
-          const b = 2
-          // last comentario
+          const b = 2 // last comentario
         }`)
       })
 
@@ -989,6 +988,7 @@ describe('Wollok Printer', () => {
           
           console.println("") 
           console.println("")
+
         }
       }`.should.be.formattedTo( `
       object foo {
@@ -1275,6 +1275,25 @@ describe('Wollok Printer', () => {
         const a = 10
         const b = 20
         self.println(a + b)
+      }`)
+    })
+
+    it('testSimpleProgramWithSpacesBetweenSends', () => {
+      `program p {
+        self.println(1)
+        self.println(2)
+
+        self.println(3)
+
+        self.println(4)
+      }`.should.be.formattedTo(`
+      program p {
+        self.println(1)
+        self.println(2)
+        
+        self.println(3)
+        
+        self.println(4)
       }`)
     })
   })


### PR DESCRIPTION
Se arreglan los comentarios después de envío de mensajes.

Eso hizo saltar la ficha de que la función `sanitizeWhitespaces` tenía un par de casos borders que faltaban. 
Lo arreglamos pero @fdodino sugería tener un función que calcule la line y la column a partir del offset: `coordinates(input, offset) -> { from, to }` 

Esto arregla el issue de nuestro querido amigo @isaiaslafon 
Fix https://github.com/uqbar-project/website-wollok-ts/issues/53