### PR TITLE
Fix #86 #212 floor for negative numbers and ceiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ src/wre/wre.json
 .nyc_output
 coverage
 wollok.log
+log/*.log

--- a/src/wre/lang.ts
+++ b/src/wre/lang.ts
@@ -537,7 +537,7 @@ const lang: Natives = {
 
       if (decimals.innerNumber! < 0) throw new RangeError('roundUp: decimals should be zero or positive number')
       if (isInteger(decimals.innerNumber!)) throw new RangeError('roundUp: decimals should be an integer number')
-      else return yield* this.reify(ceil(self.innerNumber! * 10 ** decimals.innerNumber!) / 10 ** decimals.innerNumber!)
+      return yield* this.reify(ceil(self.innerNumber! * 10 ** decimals.innerNumber!) / 10 ** decimals.innerNumber!)
     },
 
     *roundDown(self: RuntimeObject, decimals: RuntimeObject): Execution<RuntimeValue> {
@@ -545,14 +545,14 @@ const lang: Natives = {
 
       if (decimals.innerNumber! < 0) throw new RangeError('roundDown: decimals should be zero or positive number')
       if (isInteger(decimals.innerNumber!)) throw new RangeError('roundDown: decimals should be an integer number')
-      else return yield* this.reify(floor(self.innerNumber! * 10 ** decimals.innerNumber!) / 10 ** decimals.innerNumber!)
+      return yield* this.reify(floor(self.innerNumber! * 10 ** decimals.innerNumber!) / 10 ** decimals.innerNumber!)
     },
 
     *truncate(self: RuntimeObject, decimals: RuntimeObject): Execution<RuntimeValue> {
       assertIsNumber(decimals, 'truncate', '_decimals')
 
       if (decimals.innerNumber < 0) throw new RangeError('truncate: decimals should be zero or positive number')
-
+      if (isInteger(decimals.innerNumber!)) throw new RangeError('truncate: decimals should be an integer number')
       const num = self.innerNumber!.toString()
       const decimalPosition = num.indexOf('.')
       return decimalPosition >= 0

--- a/src/wre/lang.ts
+++ b/src/wre/lang.ts
@@ -536,6 +536,7 @@ const lang: Natives = {
       assertIsNumber(decimals, 'roundUp', '_decimals')
 
       if (decimals.innerNumber! < 0) throw new RangeError('roundUp: decimals should be zero or positive number')
+      if (isInteger(decimals.innerNumber!)) throw new RangeError('roundUp: decimals should be an integer number')
       else return yield* this.reify(ceil(self.innerNumber! * 10 ** decimals.innerNumber!) / 10 ** decimals.innerNumber!)
     },
 
@@ -543,6 +544,7 @@ const lang: Natives = {
       assertIsNumber(decimals, 'roundDown', '_decimals')
 
       if (decimals.innerNumber! < 0) throw new RangeError('roundDown: decimals should be zero or positive number')
+      if (isInteger(decimals.innerNumber!)) throw new RangeError('roundDown: decimals should be an integer number')
       else return yield* this.reify(floor(self.innerNumber! * 10 ** decimals.innerNumber!) / 10 ** decimals.innerNumber!)
     },
 

--- a/src/wre/lang.ts
+++ b/src/wre/lang.ts
@@ -536,8 +536,14 @@ const lang: Natives = {
       assertIsNumber(decimals, 'roundUp', '_decimals')
 
       if (decimals.innerNumber! < 0) throw new RangeError('roundUp: decimals should be zero or positive number')
+      else return yield* this.reify(ceil(self.innerNumber! * 10 ** decimals.innerNumber!) / 10 ** decimals.innerNumber!)
+    },
 
-      return yield* this.reify(ceil(self.innerNumber! * 10 ** decimals.innerNumber!) / 10 ** decimals.innerNumber!)
+    *roundDown(self: RuntimeObject, decimals: RuntimeObject): Execution<RuntimeValue> {
+      assertIsNumber(decimals, 'roundDown', '_decimals')
+
+      if (decimals.innerNumber! < 0) throw new RangeError('roundDown: decimals should be zero or positive number')
+      else return yield* this.reify(floor(self.innerNumber! * 10 ** decimals.innerNumber!) / 10 ** decimals.innerNumber!)
     },
 
     *truncate(self: RuntimeObject, decimals: RuntimeObject): Execution<RuntimeValue> {

--- a/src/wre/lang.ts
+++ b/src/wre/lang.ts
@@ -536,7 +536,7 @@ const lang: Natives = {
       assertIsNumber(decimals, 'roundUp', '_decimals')
 
       if (decimals.innerNumber! < 0) throw new RangeError('roundUp: decimals should be zero or positive number')
-      if (isInteger(decimals.innerNumber!)) throw new RangeError('roundUp: decimals should be an integer number')
+      if (!isInteger(decimals.innerNumber!)) throw new RangeError('roundUp: decimals should be an integer number')
       return yield* this.reify(ceil(self.innerNumber! * 10 ** decimals.innerNumber!) / 10 ** decimals.innerNumber!)
     },
 
@@ -544,7 +544,7 @@ const lang: Natives = {
       assertIsNumber(decimals, 'roundDown', '_decimals')
 
       if (decimals.innerNumber! < 0) throw new RangeError('roundDown: decimals should be zero or positive number')
-      if (isInteger(decimals.innerNumber!)) throw new RangeError('roundDown: decimals should be an integer number')
+      if (!isInteger(decimals.innerNumber!)) throw new RangeError('roundDown: decimals should be an integer number')
       return yield* this.reify(floor(self.innerNumber! * 10 ** decimals.innerNumber!) / 10 ** decimals.innerNumber!)
     },
 
@@ -552,7 +552,7 @@ const lang: Natives = {
       assertIsNumber(decimals, 'truncate', '_decimals')
 
       if (decimals.innerNumber < 0) throw new RangeError('truncate: decimals should be zero or positive number')
-      if (isInteger(decimals.innerNumber!)) throw new RangeError('truncate: decimals should be an integer number')
+      if (!isInteger(decimals.innerNumber!)) throw new RangeError('truncate: decimals should be an integer number')
       const num = self.innerNumber!.toString()
       const decimalPosition = num.indexOf('.')
       return decimalPosition >= 0


### PR DESCRIPTION
 - **roundDown()** and **roundUp()** son equivalentes a **floor()** and **ceil()**
Así que se pusieron como sugar. Se agregaron en **truncate(_decimals_)**, **roundDown(_decimals_)**, **roundUp(_decimals_)** excepciones al no se entero _decimals-. 
 - Se agregaron de todo los **tests** correspondientes. 

 Relacionado con el **PR** y **Branch** de language:
 - https://github.com/uqbar-project/wollok-language/pull/243
 - https://github.com/uqbar-project/wollok-language/tree/fIx-%2386-%23212-floor-negative-numbers-and-ceiling