### PR TITLE
Add object, class & mixin to REPL

### DIFF
--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -170,9 +170,7 @@ function interpreteExpression(expression: REPLExpression, interpreter: AbstractI
   if (expression.is(Import)) {
     const environment = interpreter.evaluation.environment
     if (!environment.getNodeOrUndefinedByFQN(expression.entity.name)) {
-      throw new Error(
-        `Unknown reference ${expression.entity.name}`
-      )
+      return failureResult(`Unknown reference ${expression.entity.name}`)
     }
 
     environment.newImportFor(expression)

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -128,11 +128,8 @@ const addDefinitionToREPL = (newDefinition: Class | Singleton | Mixin, interpret
 
 export function interprete(interpreter: AbstractInterpreter, line: string, frame?: Frame): ExecutionResult {
   try {
-    const parsedLine = parse.MultilineSentence.or(parse.Import).or(parse.Singleton).or(parse.Class).or(parse.Mixin).or(parse.Variable).or(parse.Assignment).tryParse(line)
-    if (Array.isArray(parsedLine)) {
-      return isEmpty(parsedLine) ? successResult('') : last(parsedLine.map(expression => interpreteExpression(expression as unknown as REPLExpression, interpreter, frame)))!
-    }
-    return interpreteExpression(parsedLine, interpreter, frame)
+    const parsedLine = parse.MultilineSentence.tryParse(line)
+    return isEmpty(parsedLine) ? successResult('') : last(parsedLine.map(expression => interpreteExpression(expression as unknown as REPLExpression, interpreter, frame)))!
   } catch (error: any) {
     return (
       error.type === 'ParsimmonError' ? failureResult(`Syntax error:\n${error.message.split('\n').filter(notEmpty).slice(1).join('\n')}`) :

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -146,6 +146,7 @@ export function interprete(interpreter: AbstractInterpreter, line: string, frame
           interpreter.do(function () { return interpreter.evaluation.exec(expression, frame) }) :
           interpreter.exec(expression)
 
+      console.info(`Environment ${interpreter.evaluation.environment.replNode().allScopedEntities().map(_ => (_ as Entity).name).join(', ')}`)
       const stringResult = !result || isVoid(result)
         ? ''
         : result.showShortValue(interpreter)

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -1,8 +1,8 @@
 import { REPL, WOLLOK_EXTRA_STACK_TRACE_HEADER } from '../constants'
-import { notEmpty } from '../extensions'
+import { isEmpty, last, notEmpty } from '../extensions'
 import { isVoid } from '../helpers'
 import { linkInNode } from '../linker'
-import { Class, Entity, Environment, Import, Method, Mixin, Module, Name, Node, Package, Reference, Sentence, Singleton } from '../model'
+import { Assignment, Class, Entity, Environment, Import, Method, Mixin, Module, Name, Node, Reference, Sentence, Singleton, Variable } from '../model'
 import * as parse from '../parser'
 import WRENatives from '../wre/wre.natives'
 import { Evaluation, Execution, ExecutionDefinition, Frame, Natives, RuntimeObject, RuntimeValue, WollokException } from './runtimeModel'
@@ -13,6 +13,8 @@ export const interpret = (environment: Environment, natives: Natives): Interpret
 // TODO: Replace this with Higher Kinded Types if TS ever implements it...
 type InterpreterResult<This, T> = This extends Interpreter ? T : ExecutionDirector<T>
 
+
+type REPLExpression = Import | Sentence | Singleton | Class | Mixin | Variable | Assignment
 
 abstract class AbstractInterpreter {
   readonly evaluation: Evaluation
@@ -117,55 +119,20 @@ export class Interpreter extends AbstractInterpreter {
 }
 
 const addDefinitionToREPL = (newDefinition: Class | Singleton | Mixin, interpreter: Interpreter) => {
-  console.info(`Adding ${newDefinition.fullyQualifiedName} to REPL`)
   const environment = interpreter.evaluation.environment
   environment.scope.register([REPL, newDefinition])
+  if (newDefinition.is(Singleton)) {
+    interpreter.evaluation.rootFrame.set(newDefinition.fullyQualifiedName, interpreter.evaluation.instantiate(newDefinition))
+  }
 }
 
 export function interprete(interpreter: AbstractInterpreter, line: string, frame?: Frame): ExecutionResult {
   try {
-    const expression = parse.Import.or(parse.Singleton).or(parse.Class).or(parse.Mixin).or(parse.Variable).or(parse.Assignment).or(parse.Expression).tryParse(line)
-    console.info(`Interpreting ${expression.kind} ${expression.is(Sentence)}`)
-    const error = [expression, ...expression.descendants].flatMap(_ => _.problems ?? []).find(_ => _.level === 'error')
-    if (error) throw error
-
-    if (expression.is(Sentence) || expression.is(Singleton) || expression.is(Class) || expression.is(Mixin)) {
-      linkInNode(expression, frame ? frame.node.parentPackage! : interpreter.evaluation.environment.replNode())
-      const unlinkedNode = [expression, ...expression.descendants].find(_ => _.is(Reference) && !_.target)
-
-      if (unlinkedNode) {
-        if (unlinkedNode.is(Reference)) {
-          if (!(frame ?? interpreter.evaluation.currentFrame).get(unlinkedNode.name))
-            return failureResult(`Unknown reference ${unlinkedNode.name}`)
-        } else return failureResult(`Unknown reference at ${unlinkedNode.sourceInfo}`)
-      }
-
-      const result = expression.is(Singleton) || expression.is(Class) || expression.is(Mixin) ?
-        addDefinitionToREPL(expression, interpreter) :
-        frame ?
-          interpreter.do(function () { return interpreter.evaluation.exec(expression, frame) }) :
-          interpreter.exec(expression)
-
-      console.info(`Environment ${interpreter.evaluation.environment.replNode().allScopedEntities().map(_ => (_ as Entity).name).join(', ')}`)
-      const stringResult = !result || isVoid(result)
-        ? ''
-        : result.showShortValue(interpreter)
-      return successResult(stringResult)
+    const parsedLine = parse.MultilineSentence.or(parse.Import).or(parse.Singleton).or(parse.Class).or(parse.Mixin).or(parse.Variable).or(parse.Assignment).tryParse(line)
+    if (Array.isArray(parsedLine)) {
+      return isEmpty(parsedLine) ? successResult('') : last(parsedLine.map(expression => interpreteExpression(expression as unknown as REPLExpression, interpreter, frame)))!
     }
-
-    if (expression.is(Import)) {
-      const environment = interpreter.evaluation.environment
-      if (!environment.getNodeOrUndefinedByFQN(expression.entity.name)) {
-        throw new Error(
-          `Unknown reference ${expression.entity.name}`
-        )
-      }
-
-      environment.newImportFor(expression)
-      return successResult('')
-    }
-
-    return successResult('')
+    return interpreteExpression(parsedLine, interpreter, frame)
   } catch (error: any) {
     return (
       error.type === 'ParsimmonError' ? failureResult(`Syntax error:\n${error.message.split('\n').filter(notEmpty).slice(1).join('\n')}`) :
@@ -176,6 +143,47 @@ export function interprete(interpreter: AbstractInterpreter, line: string, frame
   }
 }
 
+function interpreteExpression(expression: REPLExpression, interpreter: AbstractInterpreter, frame: Frame | undefined): ExecutionResult {
+  const error = [expression, ...expression.descendants].flatMap(_ => _.problems ?? []).find(_ => _.level === 'error')
+  if (error) throw error
+
+  if (expression.is(Sentence) || expression.is(Singleton) || expression.is(Class) || expression.is(Mixin)) {
+    linkInNode(expression, frame ? frame.node.parentPackage! : interpreter.evaluation.environment.replNode())
+    const unlinkedNode = [expression, ...expression.descendants].find(_ => _.is(Reference) && !_.target)
+
+    if (unlinkedNode) {
+      if (unlinkedNode.is(Reference)) {
+        if (!(frame ?? interpreter.evaluation.currentFrame).get(unlinkedNode.name))
+          return failureResult(`Unknown reference ${unlinkedNode.name}`)
+      } else return failureResult(`Unknown reference at ${unlinkedNode.sourceInfo}`)
+    }
+
+    const result = expression.is(Class) || expression.is(Mixin) || expression.is(Singleton) && !expression.isClosure() ?
+      addDefinitionToREPL(expression, interpreter) :
+      frame ?
+        interpreter.do(function () { return interpreter.evaluation.exec(expression, frame) }) :
+        interpreter.exec(expression)
+
+    const stringResult = !result || isVoid(result)
+      ? ''
+      : result.showShortValue(interpreter)
+    return successResult(stringResult)
+  }
+
+  if (expression.is(Import)) {
+    const environment = interpreter.evaluation.environment
+    if (!environment.getNodeOrUndefinedByFQN(expression.entity.name)) {
+      throw new Error(
+        `Unknown reference ${expression.entity.name}`
+      )
+    }
+
+    environment.newImportFor(expression)
+    return successResult('')
+  }
+
+  return successResult('')
+}
 
 export class DirectedInterpreter extends AbstractInterpreter {
   constructor(evaluation: Evaluation) { super(evaluation) }

--- a/src/interpreter/runtimeModel.ts
+++ b/src/interpreter/runtimeModel.ts
@@ -445,6 +445,10 @@ export class Evaluation {
     finally { if (frame) this.frameStack.pop() }
   }
 
+  instantiateSingleton(newDefinition: Singleton): void {
+    this.rootFrame.set(newDefinition.fullyQualifiedName, this.instantiate(newDefinition))
+  }
+
   protected *execTest(node: Test): Execution<void> {
     yield node
 

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -171,9 +171,8 @@ export function linkInNode<S extends Sentence | Class | Mixin | Singleton>(newSe
 
   newSentenceOrDefinition.forEach((node, parent) => {
     const id = uuid()
-    assign(node, { id })
+    assign(node, { id, environment })
     _nodeCache.set(id, node)
-    node.environment = environment
     node.parent = parent ?? context
   })
 

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from 'uuid'
 import { divideOn, is, List } from './extensions'
-import { BaseProblem, Entity, Environment, Field, Id, Import, Level, Module, Name, Node, Package, Parameter, ParameterizedType, Reference, Scope, Sentence, SourceMap, Variable } from './model'
+import { BaseProblem, Class, Entity, Environment, Field, Id, Import, Level, Mixin, Module, Name, Node, Package, Parameter, ParameterizedType, Reference, Scope, Sentence, Singleton, SourceMap, Variable } from './model'
 import { REPL } from './constants'
 const { assign } = Object
 
@@ -165,11 +165,11 @@ export default (newPackages: List<Package>, baseEnvironment?: Environment): Envi
   return environment
 }
 
-export function linkSentenceInNode<S extends Sentence>(newSentence: S, context: Node): void {
+export function linkInNode<S extends Sentence | Class | Mixin | Singleton>(newSentenceOrDefinition: S, context: Node): void {
   const { environment } = context
   const _nodeCache = environment.nodeCache as Map<Id, Node>
 
-  newSentence.forEach((node, parent) => {
+  newSentenceOrDefinition.forEach((node, parent) => {
     const id = uuid()
     assign(node, { id })
     _nodeCache.set(id, node)
@@ -177,5 +177,5 @@ export function linkSentenceInNode<S extends Sentence>(newSentence: S, context: 
     node.parent = parent ?? context
   })
 
-  assignScopes(newSentence)
+  assignScopes(newSentenceOrDefinition)
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -404,6 +404,24 @@ const sentenceError = error(MALFORMED_SENTENCE)()
 
 export const Sentence: Parser<SentenceNode> = lazy('sentence', () => alt(Variable, Return, Assignment, Expression))
 
+const sentenceSeparator = Parsimmon.alt(
+  key(';'),
+  Parsimmon.regex(/\s*/)
+)
+
+export const SentenceOrTopLevelDefinition = alt(
+  Mixin,
+  Class,
+  Singleton,
+  Sentence,
+)
+
+export const MultilineSentence = alt(
+  alt(Import, SentenceOrTopLevelDefinition).skip(sentenceSeparator),
+  comment('inner').wrap(_, _),
+  sentenceError
+).many()
+
 export const Variable: Parser<VariableNode> = node(VariableNode)(() =>
   obj({
     isConstant: alt(key(KEYWORDS.VAR).result(false), key(KEYWORDS.CONST).result(true)),

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,6 +1,6 @@
 import { expect, should, use } from 'chai'
 import sinonChai from 'sinon-chai'
-import { BOOLEAN_MODULE, Body, Class, Describe, Environment, Evaluation, Field, Import, Interpreter, isError, LIST_MODULE, Literal, Method, methodByFQN, NUMBER_MODULE, New, OBJECT_MODULE, Package, Parameter, Reference, STRING_MODULE, Self, Send, Singleton, Test, Variable, WRENatives, allAvailableMethods, allScopedVariables, allVariables, implicitImport, isNamedSingleton, isNotImportedIn, link, linkSentenceInNode, literalValueToClass, mayExecute, parentModule, parse, projectPackages, hasNullValue, hasBooleanValue, projectToJSON, getNodeDefinition, ParameterizedType, sendDefinitions, Super, SourceMap, isVoid, VOID_WKO, REPL, buildEnvironment, assertNotVoid, showParameter, getMethodContainer, Program, getExpressionFor, Expression, If, Return, possiblyReferenced } from '../src'
+import { BOOLEAN_MODULE, Body, Class, Describe, Environment, Evaluation, Field, Import, Interpreter, isError, LIST_MODULE, Literal, Method, methodByFQN, NUMBER_MODULE, New, OBJECT_MODULE, Package, Parameter, Reference, STRING_MODULE, Self, Send, Singleton, Test, Variable, WRENatives, allAvailableMethods, allScopedVariables, allVariables, implicitImport, isNamedSingleton, isNotImportedIn, link, linkInNode, literalValueToClass, mayExecute, parentModule, parse, projectPackages, hasNullValue, hasBooleanValue, projectToJSON, getNodeDefinition, ParameterizedType, sendDefinitions, Super, SourceMap, isVoid, VOID_WKO, REPL, buildEnvironment, assertNotVoid, showParameter, getMethodContainer, Program, getExpressionFor, Expression, If, Return, possiblyReferenced } from '../src'
 import { WREEnvironment, environmentWithEntities, environmentWithREPLInitializedFile } from './utils'
 import { RuntimeObject } from '../src/interpreter/runtimeModel'
 
@@ -253,21 +253,21 @@ describe('Wollok helpers', () => {
 
     it('should not execute if second parameter is not a Send object', () => {
       const assignmentForConst = parse.Variable.tryParse('const a = 1')
-      linkSentenceInNode(assignmentForConst, baseEnvironment.getNodeByFQN('repl'))
+      linkInNode(assignmentForConst, baseEnvironment.getNodeByFQN('repl'))
 
       mayExecute(testMethod)(assignmentForConst).should.be.false
     })
 
     it('should not execute if method is different', () => {
       const sendDifferentMethod = parse.Send.tryParse('aves.pepita.comer()')
-      linkSentenceInNode(sendDifferentMethod, baseEnvironment.getNodeByFQN('repl'))
+      linkInNode(sendDifferentMethod, baseEnvironment.getNodeByFQN('repl'))
 
       mayExecute(testMethod)(sendDifferentMethod).should.be.false
     })
 
     it('should execute if node receiver is a singleton and is the same method', () => {
       const sendOkSentence = parse.Send.tryParse('aves.pepita.volar()')
-      linkSentenceInNode(sendOkSentence, baseEnvironment.getNodeByFQN('repl'))
+      linkInNode(sendOkSentence, baseEnvironment.getNodeByFQN('repl'))
 
       mayExecute(testMethod)(sendOkSentence).should.be.true
     })

--- a/test/interpreter.test.ts
+++ b/test/interpreter.test.ts
@@ -167,6 +167,10 @@ describe('Wollok Interpreter', () => {
 
     describe('expressions', () => {
 
+      it('empty expression', () => {
+        checkSuccessfulResult('', '')
+      })
+
       it('value expressions', () => {
         checkSuccessfulResult('1 + 2', '3')
       })
@@ -225,6 +229,21 @@ describe('Wollok Interpreter', () => {
         checkFailedResult('const a = 2', 'Evaluation Error!')
       })
 
+      it('unlinked class should show error', () => {
+        checkFailedResult('const pepita = new Bird()', 'Unknown reference Bird')
+      })
+
+      it('missing generic import should show error', () => {
+        checkFailedResult('import some.*', 'Unknown reference some')
+      })
+
+      it('missing specific import should show error', () => {
+        checkFailedResult('import some.Bird', 'Unknown reference some.Bird')
+      })
+
+      it('parse error', () => {
+        checkFailedResult('class {}', 'Syntax Error at offset 0: class')
+      })
 
     })
 

--- a/test/interpreter.test.ts
+++ b/test/interpreter.test.ts
@@ -199,7 +199,7 @@ describe('Wollok Interpreter', () => {
       })
 
       it('not parsing strings', () => {
-        checkFailedResult('3kd3id9', 'Syntax error')
+        checkFailedResult('3kd3id9', 'Unknown reference kd3id9')
       })
 
       it('failure expressions', () => {
@@ -225,6 +225,110 @@ describe('Wollok Interpreter', () => {
         checkFailedResult('const a = 2', 'Evaluation Error!')
       })
 
+
+    })
+
+    describe('multiple sentences', () => {
+      it('should execute all sentences (no enter)', () => {
+        checkSuccessfulResult('var a = 1 ; a = a + 2; a', '3')
+      })
+
+      it('should execute all sentences (using several enters)', () => {
+        checkSuccessfulResult(`var word = "hey" ;
+          word = word + " jude";
+          word
+        `, '"hey jude"')
+      })
+
+      it('should work with imports', () => {
+        checkSuccessfulResult('import wollok.game.* ; var a = 1 ; a', '1')
+      })
+
+    })
+
+    describe('static definitions', () => {
+
+      it('class', () => {
+        checkSuccessfulResult(`class Bird {
+          var energy = 100
+          method fly() {
+            energy = energy - 10
+          }
+        }`, '')
+      })
+
+      it('mixin', () => {
+        checkSuccessfulResult(`mixin Flyier {
+          var energy = 100
+          method fly() {
+            energy = energy - 10
+          }
+        }`, '')
+      })
+
+      it('singleton', () => {
+        checkSuccessfulResult(`object pepita {
+          var energy = 100
+          method fly() {
+            energy = energy - 10
+          }
+        }`, '')
+      })
+
+      it('unnamed singleton', () => {
+        checkSuccessfulResult('object { } ', '')
+      })
+
+    })
+
+    describe('using static definitions', () => {
+      it('using a singleton', () => {
+        checkSuccessfulResult(`object pepita {
+          var energy = 100
+          method energy() = energy
+          method fly() {
+            energy = energy - 10
+          }
+        } ;
+        pepita.fly() ;
+        pepita.energy()`, '90')
+      })
+
+      it('using a class', () => {
+        checkSuccessfulResult(`class Bird {
+          var property energy = 100
+          method fly() {
+            energy = energy - 10
+          }
+        } ;
+        const pepita = new Bird() ;
+        pepita.fly() ;
+        pepita.energy()`, '90')
+      })
+
+      it('using a mixin', () => {
+        checkSuccessfulResult(`mixin Tracker {
+          var property timesTracked = 0
+          method track() {
+            timesTracked = timesTracked + 1
+          }
+        } ;
+        class Bird {
+          var property energy = 100
+          method fly() {
+            energy = energy - 10
+          }
+        };
+        const pepita = object inherits Tracker and Bird {
+          method fly() {
+            super()
+            self.track()
+          }
+        };
+        pepita.fly();
+        pepita.timesTracked()`, '1')
+      })
+
     })
 
     describe('should print result', () => {
@@ -235,12 +339,6 @@ describe('Wollok Interpreter', () => {
 
       it('for reference to an instance', () => {
         checkSuccessfulResult('new Object()', 'an Object')
-      })
-
-      it('for reference to a literal object', () => {
-        const { result, errored } = interprete(interpreter, 'object { } ')
-        result.should.include('an Object#')
-        errored.should.be.false
       })
 
       it('for number', () => {
@@ -301,7 +399,7 @@ describe('Wollok Interpreter', () => {
           name: 'persona.wlk', content: `
           class Persona {
             const enfermedades = []
-            
+
             method contraerEnfermedad(unaEnfermedad) {
 
               enfermedades.add(unaEnfermedad)
@@ -371,7 +469,7 @@ describe('Wollok Interpreter', () => {
           name: 'persona.wlk', content: `
           class Persona {
             const enfermedades = []
-            
+
             method contraerEnfermedad(unaEnfermedad) {
 
               enfermedades.add(unaEnfermedad)
@@ -491,7 +589,7 @@ describe('Wollok Interpreter', () => {
               energy = 4 * minutes + energy
             }
           }
-            
+
           class MockingBird inherits Bird {
             override method fly(minutes) {
               super([1, 2].add(4))
@@ -657,7 +755,7 @@ describe('Wollok Interpreter', () => {
               return new Date().plusDays(new Date())
             }
           }
-          
+
           class Ave {
             var energy = 100
             const formaVolar = comun

--- a/test/interpreter.test.ts
+++ b/test/interpreter.test.ts
@@ -250,11 +250,19 @@ describe('Wollok Interpreter', () => {
     describe('multiple sentences', () => {
       it('should execute all sentences (no enter)', () => {
         checkSuccessfulResult('var a = 1 ; a = a + 2; a', '3')
+        checkSuccessfulResult('var b = 1;b = b + 2;b', '3')
       })
 
-      it('should execute all sentences (using several enters)', () => {
+      it('should execute all sentences (using several enters and semicolon)', () => {
         checkSuccessfulResult(`var word = "hey" ;
           word = word + " jude";
+          word
+        `, '"hey jude"')
+      })
+
+      it('should execute all sentences (using several enters, no semicolon)', () => {
+        checkSuccessfulResult(`var word = "hey"
+          word = word + " jude"
           word
         `, '"hey jude"')
       })

--- a/test/linker.test.ts
+++ b/test/linker.test.ts
@@ -1,7 +1,7 @@
 import { expect, should, use } from 'chai'
 import { GAME_MODULE, OBJECT_MODULE, REPL } from '../src'
 import { getPotentiallyUninitializedLazy } from '../src/decorators'
-import link, { canBeReferenced, linkSentenceInNode } from '../src/linker'
+import link, { canBeReferenced, linkInNode } from '../src/linker'
 import { Body, Class, Closure, Describe, Environment, Field, Import, Method, Mixin, NamedArgument, Node, Package, Parameter, ParameterizedType, Reference, Return, Sentence, Singleton, Test, Variable, Literal } from '../src/model'
 import * as parse from '../src/parser'
 import { linkerAssertions } from './assertions'
@@ -919,7 +919,7 @@ describe('link sentence in node', () => {
     getPotentiallyUninitializedLazy(newSentence, 'parent')?.should.be.undefined
     getPotentiallyUninitializedLazy(newSentence, 'environment')?.should.be.undefined
 
-    linkSentenceInNode(newSentence, repl)
+    linkInNode(newSentence, repl)
     newSentence.id.should.be.ok
     newSentence.environment.should.be.eq(environment)
     newSentence.parent.should.be.eq(repl)
@@ -929,7 +929,7 @@ describe('link sentence in node', () => {
   it('should add new contributions to context scope', () => {
     repl.scope.localContributions().should.be.empty
 
-    linkSentenceInNode(newSentence, repl)
+    linkInNode(newSentence, repl)
     const [variableName] = repl.scope.localContributions()[0]
     variableName.should.be.equal('a')
   })


### PR DESCRIPTION
## REPL nuevo

- #351 Nos permite tener múltiples líneas en el REPL separadas por `;` (el `Enter` igual hace que dispares la evaluación de la expresión). La última expresión es lo que te devuelve al REPL.
- #350 Se pueden definir entidades como clases, objects, mixins. También acepta imports en la multiline sentence

![newREPL](https://github.com/user-attachments/assets/8f2624e3-737c-424e-a0a8-f94230f0ea5c)
