### PR TITLE
Fix #338 - método deprecado / duplicado methodExistFor

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -321,9 +321,6 @@ export const literalValueToClass = (environment: Environment, literal: LiteralVa
   return environment.getNodeByFQN(clazz)
 }
 
-export const existMethodFor = (send: Send): boolean =>
-  allAvailableMethods(send.environment).some(method => method.matchesSignature(send.message, send.numArgs))
-
 export const allAvailableMethods = (environment: Environment): Method[] =>
   environment.descendants.filter(is(Method))
 


### PR DESCRIPTION
Es básicamente eliminar un método que no se usa. Ya chequeé web-tools, cli, lsp y el sitio web. También hice

```bash
grep -rni --include="*.ts" --exclude-dir=".history" "existMethodFor" .
```

y solo vi que se usaba en ts.